### PR TITLE
OpenShift Management Role

### DIFF
--- a/playbooks/openshift-management.yml
+++ b/playbooks/openshift-management.yml
@@ -1,0 +1,5 @@
+---
+
+- hosts: openshift
+  roles:
+    - openshift-management

--- a/roles/openshift-management/README.md
+++ b/roles/openshift-management/README.md
@@ -1,0 +1,32 @@
+OpenShift Cluster Administration Role
+=============================
+
+This role performs methods to ensure the health and stability of the OpenShift Container Platform Environment
+
+## Management Features
+
+* Pruning Builds
+* Pruning Deployments
+* Pruning Images
+
+## Required Parameters
+
+The following parameters are required for the execution of this role
+
+`openshift_token` - OAuth Token associated with a user/service account with *cluster-admin* permissions
+
+## Additional Parameters
+
+Each management action has a set of parameters to tailor its' execution. Management actions contained within this role are disabled by default unless explicitly enabled. The following parameters can be configured with a value of `True` ``to enable each management action:
+
+`openshift_prune_builds`  - Pruning builds
+`openshift_prune_deployments`  - Pruning deployments
+`openshift_prune_images`  - Pruning images in the Integrated Docker Registry
+
+## Running Playbooks with this Role
+
+Prune builds, deployments and images
+
+```
+ansible-playbook -e "openshift_token=<token> openshift_prune_builds=True openshift_prune_deployments=True openshift_prune_images=True"
+```

--- a/roles/openshift-management/defaults/main.yml
+++ b/roles/openshift-management/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+openshift_token:
+openshift_master_url: localhost
+openshift_login_insecure_flag: --insecure-skip-tls-verify=true
+openshift_login_insecure: False
+openshift_prune_builds_complete: 5
+openshift_prune_builds_failed: 1
+openshift_prune_builds_keep_younger: 1h0m0s
+openshift_prune_deployments_complete: 5
+openshift_prune_deployments_failed: 1
+openshift_prune_deployments_keep_younger: 1h0m0s
+openshift_prune_images_tag_revisions: 3
+openshift_prune_images_keep_younger: 1h0m0s

--- a/roles/openshift-management/handlers/main.yml
+++ b/roles/openshift-management/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: cleanup openshift login
+  file: path="{{ kubeconfig | dirname }}" state=absent

--- a/roles/openshift-management/tasks/main.yml
+++ b/roles/openshift-management/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Validate OpenShift Token Provided
+  fail: msg="OpenShift Token Not Provided"
+  failed_when: (openshift_token is undefined) or (openshift_token is none) or (openshift_token|trim == '')
+  tags: always
+- name: Set Facts
+  set_fact: kubeconfig="/tmp/openshift-management-{{ ansible_date_time.epoch }}/config"
+  tags: always
+- name: Create Directory
+  file: path="{{ kubeconfig | dirname }}" state=directory
+  notify: cleanup openshift login
+  tags: always
+- name: Login to OpenShift
+  shell: oc login --token={{ openshift_token }} {{ openshift_login_insecure_flag }} {{ openshift_master_url }} 
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"
+  tags: always
+- include: prune-builds.yml
+  when: "{{ openshift_prune_builds | default(False) }}"
+  tags: openshift-management-builds
+- include: prune-deployments.yml
+  when: "{{ openshift_prune_deployments | default(False) }}"
+  tags: openshift-management-deployments
+- include: prune-images.yml
+  when: "{{ openshift_prune_images | default(False) }}"
+  tags: openshift-management-images

--- a/roles/openshift-management/tasks/prune-builds.yml
+++ b/roles/openshift-management/tasks/prune-builds.yml
@@ -1,0 +1,5 @@
+---
+- name: Prune Builds
+  shell: oc adm prune builds --keep-complete={{ openshift_prune_builds_complete }}  --keep-failed={{ openshift_prune_builds_failed }} --keep-younger-than={{ openshift_prune_builds_keep_younger }} --orphans --confirm
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"

--- a/roles/openshift-management/tasks/prune-deployments.yml
+++ b/roles/openshift-management/tasks/prune-deployments.yml
@@ -1,0 +1,5 @@
+---
+- name: Prune Deployments
+  shell: oc adm prune deployments --keep-complete={{ openshift_prune_deployments_complete }}  --keep-failed={{ openshift_prune_deployments_failed }} --keep-younger-than={{ openshift_prune_deployments_keep_younger }} --orphans --confirm
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"

--- a/roles/openshift-management/tasks/prune-images.yml
+++ b/roles/openshift-management/tasks/prune-images.yml
@@ -1,0 +1,5 @@
+---
+- name: Prune Images
+  shell: oc adm prune images --keep-tag-revisions={{ openshift_prune_images_tag_revisions }}  --keep-younger-than={{ openshift_prune_images_keep_younger }} --confirm
+  environment:
+    KUBECONFIG: "{{ kubeconfig }}"


### PR DESCRIPTION
#### What does this PR do?

Adds an Ansible role for performing ongoing management and ensuring stability of the OpenShift environment
#### How should this be manually tested?

Create an inventory file with an openshift group containing an OpenShift master similar to the following:

```
[openshift]
<openshift-host>
```

Obtain the OAuth token of a user with `cluster-admin` rights

Execute the role from the root of the `rhc-ose-ansible` folder to prune builds, deployments and images:

```
ansible-playbook -i inventory/openshift-management -e "openshift_token=<token> openshift_prune_images=True openshift_prune_builds=True openshift_prune_deployments=True"  playbooks/openshift-management.yml
```
#### Is there a relevant Issue open for this?

No
#### Who would you like to review this?

/cc @etsauer  @oybed @JayKayy 
