### PR TITLE
Fixing three significant bugs in the HEAT deployment

### DIFF
--- a/inventory/sample.casl.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.casl.example.com.d/inventory/group_vars/OSEv3.yml
@@ -29,7 +29,7 @@ openshift_master_identity_providers:
 #   'ca': '/etc/pki/ca-trust/source/anchors/ipa.crt'
 #openshift_master_ldap_ca_file: "{{ inventory_dir }}/../files/ipa-ca.crt"
 
-create_users:
+demo_users:
   num_users: 5
   prefix: 'rdu-user'
   passwd_file: '/etc/origin/master/htpasswd'

--- a/playbooks/openshift/plays/configure_host_groups.yml
+++ b/playbooks/openshift/plays/configure_host_groups.yml
@@ -52,6 +52,8 @@
     add_host:
       name: "{{ item }}"
       groups: masters, etcd, nodes, cluster_hosts, OSEv3, cluster_{{ env_id }}_{{ cluster_id }}
+      openshift_node_labels:
+        region: "masters"
     with_items: "{{ master_hosts }}"
     changed_when: false
 
@@ -59,6 +61,8 @@
     add_host:
       name: "{{ item }}"
       groups: nodes, cluster_hosts, OSEv3, cluster_{{ env_id }}_{{ cluster_id }}
+      openshift_node_labels:
+        region: "app"
     with_items: "{{ node_hosts }}"
     changed_when: false
 
@@ -66,6 +70,8 @@
     add_host:
       name: "{{ item }}"
       groups: nodes, cluster_hosts, OSEv3, cluster_{{ env_id }}_{{ cluster_id }}
+      openshift_node_labels:
+        region: "infra"
     with_items: "{{ infra_hosts }}"
     changed_when: false
 

--- a/playbooks/openshift/post-install.yml
+++ b/playbooks/openshift/post-install.yml
@@ -8,5 +8,5 @@
 
 - hosts: masters
   roles:
-  - { role: create_users, when: create_users is defined }
+  - { role: create_users }
 

--- a/playbooks/openshift/provision-openstack.yml
+++ b/playbooks/openshift/provision-openstack.yml
@@ -21,6 +21,10 @@
     num_nodes: "{{ openstack_num_nodes }}"
     num_infra: "{{ openstack_num_infra }}"
     num_dns: 1
+    master_volume_size: "{{ docker_volume_size }}"
+    app_volume_size: "{{ docker_volume_size }}"
+    infra_volume_size: "{{ docker_volume_size }}"
+
 
 - name: Refresh Server inventory
   hosts: localhost

--- a/roles/create_users/tasks/create_users.yml
+++ b/roles/create_users/tasks/create_users.yml
@@ -1,10 +1,10 @@
----
-# Add a user to a password file and ensure permissions are set
- - htpasswd:
-     path: "{{ users_to_create.passwd_file }}"
+ - name: "Create {{ users.num_users }} htpasswd users"
+   htpasswd:
+     path: "{{ users.passwd_file }}"
      name: "{{ item }}"
-     password: "{{ users_to_create.password }}"
+     password: "{{ users.password }}"
      owner: root
      group: root
      mode: 0600
-   with_sequence: start=0 end="{{ users_to_create.num_users }}" format="{{ users_to_create.prefix }}%02d"
+   with_sequence: start=0 end="{{ users.num_users }}" format="{{ users.prefix }}%02d"
+

--- a/roles/create_users/tasks/main.yml
+++ b/roles/create_users/tasks/main.yml
@@ -1,14 +1,15 @@
 ---
-# - include: create_users.yml
-#   when: users_to_create is defined and users_to_create != "" and users_to_create|length > 0
+ - name: "Initialize create_users facts"
+   set_fact:
+     users: ''
 
- - htpasswd:
-     path: "{{ users_to_create.passwd_file }}"
-     name: "{{ item }}"
-     password: "{{ users_to_create.password }}"
-     owner: root
-     group: root
-     mode: 0600
-   with_sequence: start=0 end="{{ users_to_create.num_users }}" format="{{ users_to_create.prefix }}%02d"
+ - name: "Take demo_user input when defined"
+   set_fact:
+     users: "{{ demo_users }}"
+   when: demo_users is defined
+
+ - include: create_users.yml  
+   static: no
+   when: False
 
 

--- a/roles/openstack-stack/tasks/main.yml
+++ b/roles/openstack-stack/tasks/main.yml
@@ -29,3 +29,6 @@
       node_flavor: "{{ node_flavor }}"
       infra_flavor: "{{ infra_flavor }}"
       dns_flavor: "{{ dns_flavor }}"
+      master_volume_size: "{{ master_volume_size }}"
+      app_volume_size: "{{ app_volume_size }}"
+      infra_volume_size: "{{ infra_volume_size }}"


### PR DESCRIPTION
#### What does this PR do?
Fixed the following issues to get HEAT provisioning to work properly

* Applied the static labels `master`, `app`, `infra` to the `masters` `node_hosts` and `infra_hosts` groups, respectively
* Configured docker to use a volume
* Fixed `create_users` such that it does not fail when you don't pass user data

#### How should this be manually tested?
ansible-playbook -i /root/repository/casl-ansible-inventories/d1.casl.rht-labs.com.d/inventory/ /root/repository/casl-ansible/playbooks/openshift/end-to-end.yml -e 'openshift_ansible_path=/root/repository/openshift-ansible'

#### Is there a relevant Issue open for this?
https://github.com/redhat-cop/casl-ansible/issues/12
https://github.com/redhat-cop/casl-ansible/issues/9

#### Who would you like to review this?
cc: @redhat-cop/casl
