### PR TITLE
Install playbook defaults to the assumption that casl-ansible and ope…

### DIFF
--- a/playbooks/openshift/install.yml
+++ b/playbooks/openshift/install.yml
@@ -1,4 +1,9 @@
 ---
-  - include: plays/configure_host_groups.yml
+- include: plays/configure_host_groups.yml
 
-  - include: "{{ openshift_ansible_path }}/playbooks/byo/config.yml"
+- hosts: all
+  vars:
+    installer_path: "{{ openshift_ansible_path | default('../../../openshift-ansible') }}"
+    
+
+- include: "{{ openshift_ansible_path | default('../../../openshift-ansible') }}/playbooks/byo/config.yml"

--- a/playbooks/openshift/install.yml
+++ b/playbooks/openshift/install.yml
@@ -1,9 +1,4 @@
 ---
 - include: plays/configure_host_groups.yml
 
-- hosts: all
-  vars:
-    installer_path: "{{ openshift_ansible_path | default('../../../openshift-ansible') }}"
-    
-
 - include: "{{ openshift_ansible_path | default('../../../openshift-ansible') }}/playbooks/byo/config.yml"


### PR DESCRIPTION
…nshift-ansible are checked out to the same directory

#### What does this PR do?
With this commit, we don't have to specify `openshift_ansible_path` in an `end-to-end.yml` run. The playbook will assume that your directory structure looks like:

```
- somedir
 \ - casl-ansible
 \ - openshift-ansible
```

Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

```
ansible-playbook -i casl-ansible-inventories/sample.casl.example.com/inventory casl-ansible/playbooks/openshift/end-to-end.yml
```

#### Is there a relevant Issue open for this?
https://github.com/redhat-cop/casl-ansible/issues/3

#### Who would you like to review this?
cc: @redhat-cop/casl
