### PR TITLE
Updating to development release of ansible 2.3.0 to pull down bug fix…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ To start, we'll provision the `sample.casl.example.com` cluster defined in the `
 ansible-playbook -i /root/repository/casl-ansible/inventory/sample.casl.example.com.d/inventory /root/repository/casl-ansible/playbooks/openshift/end-to-end.yml
 ```
 
+### Updating a Cluster
+
+Once provisioned, a cluster may be adjusted/reconfigured as needed by updating inventory and re-running the `end-to-end.yml` playbook.
+
+### Scaling Up and Down
+
+A cluster's Infra and App nodes may be scaled up and down by editing the following parameters in the `hosts` or `all.yml` files
+
+```
+openstack_num_nodes=1
+openstack_num_infra=1
+```
+
+and then re-running the playbook.
+
+```
+ansible-playbook -i /root/repository/casl-ansible/inventory/sample.casl.example.com.d/inventory /root/repository/casl-ansible/playbooks/openshift/end-to-end.yml
+```
+
+
 ## Roles
 
 The following are a list of Absible roles available

--- a/docker/openstack-client-centos/Dockerfile
+++ b/docker/openstack-client-centos/Dockerfile
@@ -8,7 +8,7 @@ ADD bin/start.sh /root/
 RUN yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/openstack/openstack-mitaka/rdo-release-mitaka-6.noarch.rpm centos-release-openshift-origin; \
   yum update -y; \
   yum install -y python-devel epel-release; \
-  yum install -y git tar gcc libffi-devel openssl-devel bind-utils ansible \
+  yum install -y git tar gcc libffi-devel openssl-devel bind-utils \
                  python-pip python-ceilometerclient \
                  python-cinderclient python-glanceclient \
                  python-heatclient python-neutronclient \
@@ -18,7 +18,8 @@ RUN yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/
                  pyOpenSSL \
                  origin-clients; \
   yum clean all; \
-  pip install shade
+  pip install shade; \
+  pip install git+git://github.com/ansible/ansible.git@devel
 
 # Set /root as starting directory
 WORKDIR /root


### PR DESCRIPTION
…es in HEAT module

#### What does this PR do?
Pulls in ansible 2.3.0 from the development release. This contains an important fix to the `os_stack` module that allows for idempotency of the infrastructure. This, in turn gives us the ability to scale openshift clusters up and down.

Couple of notes on this:
- I've only updated the centos image for now, as this is temporary until ansible 2.3.0 is released.
- Currently, if infranodes are scaled out the router will not scale with them. I've submitted a fix upstream for this: https://github.com/openshift/openshift-ansible/pull/3340

#### How should this be manually tested?
Rebuild the centos docker image, then run a provisioning job from instructions from the README.

#### Is there a relevant Issue open for this?


#### Who would you like to review this?
cc: @redhat-cop/casl
