### PR TITLE
Updating to OSP ocata repo, as there are some bugs with newton's channel

### DIFF
--- a/docker/control-host-openstack/Dockerfile
+++ b/docker/control-host-openstack/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 MAINTAINER Andrew Block “andrew.block@redhat.com”
 
 # Update System and install clients
-RUN yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/openstack/openstack-newton/rdo-release-newton-4.noarch.rpm centos-release-openshift-origin; \
+RUN yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/openstack/openstack-ocata/rdo-release-ocata-3.noarch.rpm centos-release-openshift-origin; \
   yum update -y; \
   yum install -y python-devel epel-release; \
   yum install -y git tar gcc libffi-devel openssl-devel bind-utils httpd-tools java-1.8.0-openjdk-headless\


### PR DESCRIPTION
#### What does this PR do?
Changes our control host image to use the rpm channel for OSP 11 instead of 10. The OSP 10 repo seems to have some issues with packages, specifically the issue here: https://github.com/openshift/openshift-ansible/issues/4111

#### How should this be manually tested?
```
docker build -t redhatcop/openstack-client-centos .
docker-compose rm
docker-compose up -d
```

Then run through normal provisioning flow, per README.

#### Is there a relevant Issue open for this?
https://github.com/openshift/openshift-ansible/issues/4111

#### Who would you like to review this?
cc: @redhat-cop/casl
