### PR TITLE
Upgrading jinja2 to work correctly with latest templates

### DIFF
--- a/docker/control-host-openstack/Dockerfile
+++ b/docker/control-host-openstack/Dockerfile
@@ -17,6 +17,7 @@ RUN yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/
                  origin-clients; \
   yum clean all; \
   pip install --upgrade pip; \
+  pip install --upgrade jinja2; \
   pip install shade six git+git://github.com/ansible/ansible.git@stable-2.3
 
 ADD bin/start.sh /root/


### PR DESCRIPTION
#### What does this PR do?
Upgrading `python-jinja2` to allow for the latest template processing

#### How should this be manually tested?
re-run the complete CASL provisioning 

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
