### PR TITLE
Added role to deploy acme controller as part of the post install activities

### DIFF
--- a/playbooks/openshift/post-install.yml
+++ b/playbooks/openshift/post-install.yml
@@ -8,3 +8,6 @@
   roles:
   - { role: create_users }
 
+- hosts: masters[0]
+  roles:
+  -  role: acme

--- a/roles/acme/defaults/main.yml
+++ b/roles/acme/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+
+acme_project: acme
+acme_repo: https://github.com/tnozicka/openshift-acme.git
+acme_repo_branch: master
+acme_service_account: acme
+acme_local_dir: /tmp/git/acme
+acme_resources_dir: deploy
+cluster_role_file: clusterrole.yaml
+deployment_file: deployment-letsencrypt-live.yaml
+service_file: service.yaml
+acme_deployment_name: acme-controller
+acme_cluster_role_name: acme-controller

--- a/roles/acme/tasks/main.yml
+++ b/roles/acme/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+
+- name: Clone Git Repository
+  git:
+    repo: "{{ acme_repo }}"
+    dest: "{{ acme_local_dir }}"
+    force: yes
+
+- name: Check if project exists
+  shell: "oc get project {{ acme_project }}"
+  ignore_errors: True
+  register: acme_project_check
+
+- name: Create acme Project
+  shell: "oc adm new-project {{ acme_project }}"
+  when: acme_project_check | failed
+
+- name: Check if Service Account Exists
+  shell: "oc get serviceaccount {{ acme_service_account }} -n {{ acme_project }}"
+  ignore_errors: True
+  register: acme_service_account_check
+
+- name: Create acme Service Account
+  shell: "oc create serviceaccount {{ acme_service_account }} -n {{ acme_project }}"
+  when: acme_service_account_check | failed
+
+- name: Fix missing API version
+  lineinfile:
+    dest: "{{ acme_local_dir }}/{{ acme_resources_dir }}/{{ cluster_role_file }}"
+    regexp: "^apiVersion"
+    line: "apiVersion: v1"
+    insertbefore: BOF
+
+- name: Apply Cluster Role
+  shell: "oc apply -f {{ acme_local_dir }}/{{ acme_resources_dir }}/{{ cluster_role_file }} -n {{ acme_project }}"
+
+- name: Grant ACME Service Account Custom Role
+  shell: "oc adm policy add-cluster-role-to-user {{ acme_cluster_role_name }} system:serviceaccount:{{ acme_project }}:{{ acme_service_account }}"
+
+- name: Apply Acme Deployment
+  shell: "oc apply -f {{ acme_local_dir }}/{{ acme_resources_dir }}/{{ deployment_file }} -n {{ acme_project }}"
+
+- name: Patch DeploymentConfig
+  command: >
+      oc patch deployment/{{ acme_deployment_name }} --patch '{"spec":{"template":{"spec":{"serviceAccountName": "{{ acme_service_account }}"}}}}'
+
+- name: Apply Acme Service
+  shell: "oc apply -f {{ acme_local_dir }}/{{ acme_resources_dir }}/{{ service_file }} -n {{ acme_project }}"  
+
+- name: Remove Git Directory
+  file:
+    path: "{{ acme_local_dir }}"
+    state: absent

--- a/roles/acme/tasks/main.yml
+++ b/roles/acme/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: Patch DeploymentConfig
   command: >
-      oc patch deployment/{{ acme_deployment_name }} --patch '{"spec":{"template":{"spec":{"serviceAccountName": "{{ acme_service_account }}"}}}}'
+      oc patch deployment/{{ acme_deployment_name }} --patch '{"spec":{"template":{"spec":{"serviceAccountName": "{{ acme_service_account }}"}}}}' -n {{ acme_project }}
 
 - name: Apply Acme Service
   shell: "oc apply -f {{ acme_local_dir }}/{{ acme_resources_dir }}/{{ service_file }} -n {{ acme_project }}"  


### PR DESCRIPTION
#### What does this PR do?
Adds an ACME controller based on the [openshift-acme](https://github.com/tnozicka/openshift-acme) repository to the post provisioning steps 

#### How should this be manually tested?
Have an OpenShift environment available. You can validate the execution by creating a playbook with the following content

```
- hosts: masters[0]
  roles:
    - acme
```

Create an inventory with the following content

```
[masters]
<insert host>
```
As a result, a new project called `acme` will be created with a pod running inside

#### Is there a relevant Issue open for this?
https://trello.com/c/0kjfpxiH

#### Who would you like to review this?
cc: @redhat-cop/casl
