### PR TITLE
Adding clean failure message for missing params file

### DIFF
--- a/roles/oc-apply/tasks/process-one-entry.yml
+++ b/roles/oc-apply/tasks/process-one-entry.yml
@@ -5,6 +5,18 @@
     process_f: ''
     target_namespace: ''
 
+- name: "Check if params file exists"
+  stat:
+    path: "{{ item.params }}"
+  ignore_errors: yes
+  register: params_result
+
+- name: "Fail if params file doesn't exist"
+  fail:
+    msg: "{{ item.params }} - params file doesn't exist."
+  when:
+  - params_result.stat.exists == False
+
 - name: "Check if the passed in template is a remote location (URL)"
   uri:
     url: "{{ item.template }}"


### PR DESCRIPTION
#### What does this PR do?
This will make a failed run due to a missing params file have a more useful failure message.

#### How should this be manually tested?
Using the test in the test directory for this role. In your inventory variables you are running against, change the name of the params file, then run the test.

#### Is there a relevant Issue open for this?
[#61](https://github.com/redhat-cop/casl-ansible/issues/61)

The scope of this issue changed as a result of a previous PR.

#### Who would you like to review this?
cc: @redhat-cop/casl @oybed 
