### PR TITLE
Adding failed_when check to make sure it doesn't fail for local files

### DIFF
--- a/roles/oc-apply/tasks/process-one-entry.yml
+++ b/roles/oc-apply/tasks/process-one-entry.yml
@@ -20,8 +20,9 @@
 - name: "Check if the passed in template is a remote location (URL)"
   uri:
     url: "{{ item.template }}"
-  ignore_errors: yes
   register: url_result
+  failed_when:
+  - '"unknown url" not in url_result.msg and url_result.url is not defined'
 
 - name: "Check if passed in template is a local file (if not remote location)"
   stat:
@@ -29,13 +30,13 @@
   ignore_errors: yes
   register: file_result
   when:
-  - (url_result.failed is defined and url_result.failed) or (url_result.status is defined and url_result.status != 200)
+  - '"unknown url" in url_result.msg or (url_result.status is defined and url_result.status != 200)'
 
 - name: "Set the '-f' option if the template is either a remote or local file"
   set_fact:
     process_f: ' -f '
-  when: 
-  - (url_result.failed is defined and not url_result.failed) or (url_result.status is defined and url_result.status == 200) or file_result.stat.exists 
+  when:
+  - '"unknown url" not in url_result.msg or file_result.stat.exists'
 
 - name: "Set the target namespace option if supplied"
   set_fact:


### PR DESCRIPTION
#### What does this PR do?
Previously, the "Check if the passed in template is a remote location (URL)" task need `ignore-errors: yes` since it would fail if the template wasn't a remote location.

This PR adds a failed_when check which will make it so it doesn't fail when it is a local template or a oob template.

#### How should this be manually tested?
Run the test playbook included with the role. Ideally, the inventory you include would use a remote template, a local template, and an oob template. 

#### Is there a relevant Issue open for this?
[#70](https://github.com/redhat-cop/casl-ansible/issues/70)

#### Who would you like to review this?
cc: @redhat-cop/casl @oybed 
