### PR TITLE
Adjusting seed cluster step to take advantage of system:admin on the …

### DIFF
--- a/playbooks/openshift/post-install.yml
+++ b/playbooks/openshift/post-install.yml
@@ -8,6 +8,8 @@
   roles:
   - { role: create_users }
 
-- include: ../openshift-cluster-seed.yml
+- hosts: masters[0]
+  roles:
+    - openshift-applier
   when:
   - openshift_cluster_content is defined


### PR DESCRIPTION
…master

#### What does this PR do?
runs the openshift-applier role from first master.

#### How should this be manually tested?
Run through `playbooks/openshift/end-to-end.yml` or `playbooks/openshift/post-install.yml` on an existing cluster

#### Is there a relevant Issue open for this?
depends on https://github.com/redhat-cop/casl-ansible/pull/81

#### Who would you like to review this?
cc: @redhat-cop/casl
