### PR TITLE
Updating standard post-install playbooks to include cluster-seed step

### DIFF
--- a/inventory/s1-ha.casl.example.com.d/inventory/hosts
+++ b/inventory/s1-ha.casl.example.com.d/inventory/hosts
@@ -46,3 +46,6 @@ infra.s1-ha.casl.example.com
 [nodes.s1-ha.casl.example.com]
 [infra.s1-ha.casl.example.com]
 [dns.s1-ha.casl.example.com]
+
+[seed-hosts:children]
+masters

--- a/inventory/sample.casl.example.com.d/inventory/hosts
+++ b/inventory/sample.casl.example.com.d/inventory/hosts
@@ -42,3 +42,6 @@ dns.sample.casl.example.com
 [infra.sample.casl.example.com]
 [nodes.sample.casl.example.com]
 [dns.sample.casl.example.com]
+
+[seed-hosts:children]
+masters

--- a/playbooks/openshift-cluster-seed.yml
+++ b/playbooks/openshift-cluster-seed.yml
@@ -1,4 +1,4 @@
 ---
-- hosts: localhost
+- hosts: masters[0]
   roles:
     - openshift-applier

--- a/playbooks/openshift-cluster-seed.yml
+++ b/playbooks/openshift-cluster-seed.yml
@@ -1,4 +1,4 @@
 ---
-- hosts: masters[0]
+- hosts: seed-hosts[0]
   roles:
     - openshift-applier

--- a/playbooks/openshift/post-install.yml
+++ b/playbooks/openshift/post-install.yml
@@ -8,8 +8,6 @@
   roles:
   - { role: create_users }
 
-- hosts: masters[0]
-  roles:
-    - openshift-applier
+- include: ../openshift-cluster-seed.yml
   when:
   - openshift_cluster_content is defined


### PR DESCRIPTION
#### What does this PR do?
Fixes post install playbook to take advantage of recent `openshift-applier` changes.

#### How should this be manually tested?
```
ansible-playbook -i casl-ansible/sample.example.com/inventory/ code/casl-ansible/playbooks/openshift/post-install.yml
```

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/casl
