### PR TITLE
adding whitelist feature

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -93,6 +93,17 @@ These objects look like this:
 **_NOTE:_** If the target namespace is not defined in each of the objects within the template, be sure to add the `namespace` variable. 
 
 
+Executing a Subset of the Inventory
+------------
+
+When developing an inventory, it can be useful to only apply a subset of the inventory during a single playbook execution. The role current has a "whitelist" feature, which will only apply the `objects` you specify in an environment variable `wl`. It's most practical to set this with the `-e` or `--extra-vars` switch of `ansible-playbook`, so you don't need to modify any source files. The below example will apply only the `projectrequest` and `app-builds` objects in the inventory, skipping any others that exist:
+
+`ansible-playbook -i <inventory> <playbook> -e "wl=projectrequest,app-builds"`
+
+
+
+
+
 Dependencies
 ------------
 - openshift-login: Ansible role used to login a user to the OpenShift cluster.

--- a/roles/openshift-applier/tasks/main.yml
+++ b/roles/openshift-applier/tasks/main.yml
@@ -9,6 +9,9 @@
 # We need to create a few objects first,
 # hence the special handling up front of these ...
 
+- name: "Process Whitelist"
+  include: process-whitelist.yml
+
 - name: "Build special handling list"
   set_fact:
     special_handling:
@@ -28,6 +31,7 @@
   when:
   - case.0.object is defined
   - case.0.object == case.1
+  - case.0.object in whitelist
 
 - name: "Eliminate the special handling cases now that they are done"
   set_fact:
@@ -40,6 +44,7 @@
   when:
   - case.0.object is defined
   - case.0.object != case.1
+  - case.0.object in whitelist
 
 - name: "Create OpenShift cluster wide objects"
   vars:
@@ -51,6 +56,7 @@
     loop_var: entry
   when:
   - entry.content is defined or entry.content_dir is defined
+
 
 - name: "Create OpenShift objects with params"
   include: process-content.yml

--- a/roles/openshift-applier/tasks/process-whitelist.yml
+++ b/roles/openshift-applier/tasks/process-whitelist.yml
@@ -6,7 +6,7 @@
   - wl is defined
   - wl != ""  
 
-- name: "Creat Default Whitelist"
+- name: "Create Default Whitelist"
   set_fact:
     whitelist: [] 
   when:

--- a/roles/openshift-applier/tasks/process-whitelist.yml
+++ b/roles/openshift-applier/tasks/process-whitelist.yml
@@ -1,0 +1,19 @@
+--- 
+- name: "Convert whitelist to json list from comma deliminited list"
+  set_fact:
+    whitelist: "{{wl.split(',') }}"
+  when:
+  - wl is defined
+  - wl != ""  
+
+- name: "Creat Default Whitelist"
+  set_fact:
+    whitelist: [] 
+  when:
+  - wl is not defined or wl == "" 
+
+- name: "Convert whitelist to json list from comma deliminited list"
+  set_fact:
+    whitelist: "{{ whitelist }} + [ '{{item.object}}' ]"
+  with_items:
+  - "{{openshift_cluster_content}}"

--- a/roles/openshift-applier/tasks/process-whitelist.yml
+++ b/roles/openshift-applier/tasks/process-whitelist.yml
@@ -17,3 +17,5 @@
     whitelist: "{{ whitelist }} + [ '{{item.object}}' ]"
   with_items:
   - "{{openshift_cluster_content}}"
+  when:
+  - wl is not defined or wl == "" 


### PR DESCRIPTION
#### What does this PR do?
Enables end users to specify a variable `wl`, which a comma delimited list of objects in the inventory to process. Any object not named in the list, will not be processed. Thus, a whitelist.

#### How should this be manually tested?
README provides an example when turning the feature on. If the feature is not activated, the role will automatically add all objects to the whitelist.

#### Is there a relevant Issue open for this?
resolves #90 

#### Who would you like to review this?
cc: @redhat-cop/casl
