### PR TITLE
Allow for idempotent creation of specified objects

### DIFF
--- a/roles/oc-apply/tasks/main.yml
+++ b/roles/oc-apply/tasks/main.yml
@@ -30,7 +30,7 @@
   when:
   - entry.object not in [ 'namespace', 'policy' ]
 
-- name: "Create OpenShift objects with params"
+- name: "Create OpenShift objects with params (non-idempotent)"
   include: process-content.yml
   with_items:
   - "{{ openshift_cluster_content }}"
@@ -39,3 +39,13 @@
   when:
   - entry.object not in [ 'namespace', 'policy' ]
   - entry.content is defined 
+
+- name: "Create OpenShift objects with params (idempotent)"
+  include: process-idempotent.yml
+  with_items:
+  - "{{ openshift_cluster_content }}"
+  loop_control:
+    loop_var: entry
+  when:
+  - entry.object not in [ 'namespace', 'policy' ]
+  - entry.content is defined

--- a/roles/oc-apply/tasks/process-content.yml
+++ b/roles/oc-apply/tasks/process-content.yml
@@ -6,6 +6,7 @@
   with_items:
   - "{{ entry.content }}"
   when:
+  - item.idempotent is undefined
   - item.template is defined 
   - item.template != ''
   - item.params is defined

--- a/roles/oc-apply/tasks/process-idempotent.yml
+++ b/roles/oc-apply/tasks/process-idempotent.yml
@@ -1,0 +1,15 @@
+---
+
+- name: "Create OpenShift objects for '{{ entry.object }}' with params"
+  shell: >
+    oc process -f {{ item.template }} --param-file={{ item.params }} | oc create -n {{ lookup('ini', 'NAMESPACE type=properties file=' ~ item.params) }} -f -
+  with_items:
+  - "{{ entry.content }}"
+  ignore_errors: yes
+  when:
+  - item.idempotent is defined
+  - item.template is defined 
+  - item.template != ''
+  - item.params is defined
+  - item.params != ''
+  - lookup('ini', 'NAMESPACE type=properties file=' ~ item.params) is defined


### PR DESCRIPTION
#### What does this PR do?
Add new task `process-idempotent` to role `oc-apply`
which can handle idempotently creating objects
in OpenShift.

#### How should this be manually tested?
Add the field `idempotent` to an object to be created from a template and run the inventory.
Run the same inventory again and verify that the object is unchanged

#### Is there a relevant Issue open for this?
Resolves #98 

#### Who would you like to review this?
cc: @oybed @sherl0cks
