### PR TITLE
Making pv cleanup part of decommissioning a cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 roles/infra-ansible
 roles/openshift-ansible-contrib
+*.pyc

--- a/playbooks/openshift/delete-cluster.yml
+++ b/playbooks/openshift/delete-cluster.yml
@@ -1,8 +1,8 @@
 ---
 - hosts: seed-hosts
   roles:
-  - roles/openshift-ansible-contrib/openshift-pv-cleanup
+  - openshift-ansible-contrib/roles/openshift-pv-cleanup
 
 - include: delete-openstack.yml
-  when: 
+  when:
   - hosting_infrastructure == 'openstack'

--- a/playbooks/openshift/delete-cluster.yml
+++ b/playbooks/openshift/delete-cluster.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: seed-hosts
   roles:
-  - openshift-pv-cleanup
+  - roles/openshift-ansible-contrib/openshift-pv-cleanup
 
 - include: delete-openstack.yml
   when: 

--- a/playbooks/openshift/delete-cluster.yml
+++ b/playbooks/openshift/delete-cluster.yml
@@ -1,4 +1,7 @@
 ---
+- hosts: seed-hosts
+  roles:
+  - openshift-pv-cleanup
 
 - include: delete-openstack.yml
   when: 


### PR DESCRIPTION
#### What does this PR do?
Deletes pvs before cluster delete

#### How should this be manually tested?
Provision a cluster with dynamic provisioning enabled. Ensure some pvcs get created and bound. Then delete the cluster with the following:

```
ansible-playbook -i /path/to/inventory casl-ansible/playbooks/openshift/delete-cluster.yml
```

Now log into cloud and make sure that the kubernetes volumes are all cleaned up.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/casl
