### PR TITLE
Fix registry storage variable name

### DIFF
--- a/playbooks/openshift/cinder-registry.yml
+++ b/playbooks/openshift/cinder-registry.yml
@@ -9,7 +9,7 @@
   - name: "set registry volumeID fact"
     set_fact: 
       openshift_hosted_registry_storage_openstack_volumeID: "{{ disk.volume.id }}"
-      openshift_hosted_registry_storage_openstack_volume_size: "{{ disk.volume.size }}Gi"
+      openshift_hosted_registry_storage_volume_size: "{{ disk.volume.size }}Gi"
     with_items: 
     -  "{{ hostvars['localhost'].os_volumes.results }}"
     when: 


### PR DESCRIPTION
#### What does this PR do?
Fix registry storage variable name in cinder-registry playbook.   With this change the cluster registry-claim will now consume 100% of the allocated storage and not the default 5Gi

#### How should this be manually tested?
Define inventory to utilized Openstack cinder storage for Registry.

After cluster deployment, verify that the `registry-claim` is the same size as defined in inventory via:
`oc get pv`

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl @etsauer @oybed
