### PR TITLE
AWS: Docker Image for AWS Control Host

### DIFF
--- a/images/installer-aws/Dockerfile
+++ b/images/installer-aws/Dockerfile
@@ -1,0 +1,15 @@
+FROM openshift/origin-ansible
+
+USER root
+
+RUN yum install -y python2-boto python2-pip && \
+    pip install boto3
+
+RUN sed -i 's/inventory_ignore_extensions =\(.*\)/inventory_ignore_extensions =\1, .ini/g' /usr/share/ansible/openshift-ansible/ansible.cfg
+
+COPY images/installer-aws/root /
+
+USER ${USER_UID}
+
+ENTRYPOINT [ "/usr/local/bin/entrypoint_casl" ]
+CMD [ "/usr/local/bin/run" ]

--- a/images/installer-aws/README.md
+++ b/images/installer-aws/README.md
@@ -1,0 +1,59 @@
+AWS Docker Client
+==================
+
+Produces a container capable of acting as a client for AWS
+
+## Setup
+
+The following steps are required to run the docker client.
+
+1. Install docker
+  1. on RHEL/Fedora: ```{yum/dnf} install docker```
+  2. on Windows: [Install Docker for Windows](https://docs.docker.com/windows/step_one/)
+  3. on OSX: [Max OS X](https://docs.docker.com/installation/mac/)
+  4. on all other Operating Systems: [Supported Platforms](https://docs.docker.com/installation/)
+2. Give your user access to run Docker containers (this is only required in Linux/Unix distros)
+```
+groupadd docker
+usermod -a -G docker ${USER}
+systemctl enable docker
+systemctl restart docker
+```
+
+## Running
+
+A typical run of the image would look like:
+
+```
+docker run -u `id -u` \
+      -v $HOME/.ssh:/opt/app-root/src/.ssh \
+      -v $HOME/aws-credentials.csv:/opt/app-root/src/aws-credentials.csv \
+      -v $HOME/src/:/tmp/src \
+      -e INVENTORY_DIR=/tmp/src/casl-ansible/inventory/sample.aws.example.com.d/inventory/ \
+      -e PLAYBOOK_FILE=/tmp/src/casl-ansible/playbooks/openshift/end-to-end.yml \
+      -e OPTS="-e aws_key_name=my-public-key" -t \
+      redhatcop/installer-aws
+```
+
+The above commands expects the following inputs:
+* Your ssh key (~/.ssh/id_rsa) to be mounted in the container at `/opt/app-root/src/.ssh/id_rsa`
+* Your AWS credentials (in CSV format) is available in your home directory
+* Your ansible inventories and playbooks repos to live within the same directory, mounted at `/tmp/src`
+
+> **Note:** The AWS credentials file can be using the .csv as downloaded from AWS, or a .sh file can be used and will be sourced as-is (make sure the **AWS_SECRET_ACCESS_KEY** and **AWS_ACCESS_KEY_ID** environment variables are exported correctly).
+
+## Building the Image
+
+This image is built and published to docker.io, so there's no reason to build it if you're just wanting to use the latest stable version. However, if you need to build it for development reasons, here's how:
+
+```
+cd ./casl-ansible
+docker build -f images/installer-aws/Dockerfile -t redhatcop/installer-aws .
+```
+
+## Troubleshooting
+
+Below are some of helpful hints for resolving issues experiencing while configuring and running the container
+
+TBD
+

--- a/images/installer-aws/root/usr/local/bin/aws-keys
+++ b/images/installer-aws/root/usr/local/bin/aws-keys
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Example CSV file #1:
+# User name,Password,Access key ID,Secret access key,Console login link
+# user,,AKIAJWYSDFSDFPQW5VFA,EqdiwsWYtDFwZNxAcJU+X1mPRtRLQ4Hve,https://example.signin.aws.amazon.com/console
+
+# Example CSV file #2:
+# Access key ID,Secret access key
+# AKIAJWYSDFSDFPQW5VFA,EqdiwsWYtDFwZNxAcJU+X1mPRtRLQ4Hve
+
+# Default files
+# The CSV file is based on AWS specific CSV files
+# The SH file is just a .sh with whatever content the user has - i.e.: the file will be sourced as-is
+CSV_FILE=~/aws-credentials.csv
+SH_FILE=~/aws-credentials.sh
+
+# Array used to determine the information sourced from the CSV file
+declare -A AWS_entries
+AWS_entries[AWS_ACCESS_KEY_ID]="Access key ID"
+AWS_entries[AWS_SECRET_ACCESS_KEY]="Secret access key"
+
+function parse_csv_file()
+{
+  # Don't do anything if the CSV file doesn't exists
+  if [ ! -f ${CSV_FILE} ]
+  then
+    return
+  fi
+
+  # The CSV has a header line (line 1) and a value line (line 2)
+  csv_headers=`head -n 1 ${CSV_FILE} | tr -d '\r\n'`
+  csv_values=`tail -n 1 ${CSV_FILE} | tr -d '\r\n'`
+
+  # Loop through all the AWS entries of interest to find them...
+  for k in "${!AWS_entries[@]}"
+  do 
+    found=0
+
+    # Let's process up to 9 items on a line (9 is a "wild guess" for a max, but seems enough)
+    for i in 1 2 3 4 5 6 7 8 9;
+    do
+      # Extract one-by-one until the one of interest is found
+      extract=`echo $csv_headers | cut -d ',' -f $i`
+      if [[ "${AWS_entries[$k]}" == "${extract}" ]]
+      then
+        found=${i}
+        break;
+      fi
+    done
+
+    # If found, apply it to the current environment
+    if [ ${found} != 0 ]
+    then
+      export ${k}=`echo ${csv_values} | cut -d ',' -f ${found}`
+    fi
+  done
+}
+
+function apply_sh_file()
+{
+  # Don't do anything if the .sh file doesn't exists
+  if [ ! -f ${SH_FILE} ]
+  then
+    return
+  fi
+
+  # Just apply the .sh file as-is
+  source ${SH_FILE}
+}
+
+parse_csv_file
+apply_sh_file

--- a/images/installer-aws/root/usr/local/bin/entrypoint_casl
+++ b/images/installer-aws/root/usr/local/bin/entrypoint_casl
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /usr/local/bin/aws-keys
+
+source /usr/local/bin/entrypoint

--- a/images/installer-openstack/README.md
+++ b/images/installer-openstack/README.md
@@ -7,8 +7,8 @@ Produces a container capable of acting as a client for OpenStack
 
 The following steps are required to run the docker client.
 
-1. Install docker and docker-compose
-  1. on RHEL/Fedora: ```{yum/dnf} install docker docker-compose```
+1. Install docker
+  1. on RHEL/Fedora: ```{yum/dnf} install docker```
   2. on Windows: [Install Docker for Windows](https://docs.docker.com/windows/step_one/)
   3. on OSX: [Max OS X](https://docs.docker.com/installation/mac/)
   4. on all other Operating Systems: [Supported Platforms](https://docs.docker.com/installation/)
@@ -26,12 +26,12 @@ A typical run of the image would look like:
 
 ```
 docker run -u `id -u` \
-      -v $HOME/.ssh/id_rsa:/opt/app-root/src/.ssh/id_rsa:Z \
-      -v $HOME/src/:/tmp/src:Z \
+      -v $HOME/.ssh/id_rsa:/opt/app-root/src/.ssh/id_rsa \
+      -v $HOME/src/:/tmp/src \
       -v $HOME/.config/openstack/:/opt/app-root/src/.config/openstack/ \
-      -e INVENTORY_DIR=/tmp/src/casl-ansible/inventory/sample.casl.example.com.d/inventory/ \
+      -e INVENTORY_DIR=/tmp/src/casl-ansible/inventory/sample.osp.example.com.d/inventory/ \
       -e PLAYBOOK_FILE=/tmp/src/casl-ansible/playbooks/openshift/end-to-end.yml \
-      -e OPTS="-v openstack_ssh_public_key=my-public-key" -t \
+      -e OPTS="-e openstack_ssh_public_key=my-public-key" -t \
       redhatcop/installer-openstack
 ```
 
@@ -53,30 +53,16 @@ docker build -f images/installer-openstack/Dockerfile -t redhatcop/installer-ope
 
 Below are some of helpful hints for resolving issues experiencing while configuring and running the container
 
-**Issue #1**
+**Issue**
+
+Getting "permission denied" when attempting to run the docker image, e.g. something similar to:
 
 ```
-$ ./run.sh
-time="2015-09-01T11:22:05-04:00" level=fatal msg="Get http:///var/run/docker.sock/v1.18/images/json: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?"
-Building Docker Image rhtconsulting/rhc-openstack-client....
-Sending build context to Docker daemon
-FATA[0000] Post http:///var/run/docker.sock/v1.18/build?cgroupparent=&cpusetcpus=&cpushares=0&dockerfile=Dockerfile&memory=0&memswap=0&rm=1&t=rhtconsulting%2Frhc-openstack-client: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
-```
-
-**Resolution #1**
-
-Verify the Docker service is running
-
-**Issue #2**
-
-```
-./run.sh
+ :
 time="2015-09-01T11:32:36-04:00" level=fatal msg="Get http:///var/run/docker.sock/v1.18/images/json: dial unix /var/run/docker.sock: permission denied. Are you trying to connect to a TLS-enabled daemon without TLS?"
-Building Docker Image rhtconsulting/rhc-openstack-client....
-Sending build context to Docker daemon
-FATA[0000] Post http:///var/run/docker.sock/v1.18/build?cgroupparent=&cpusetcpus=&cpushares=0&dockerfile=Dockerfile&memory=0&memswap=0&rm=1&t=rhtconsulting%2Frhc-openstack-client: dial unix /var/run/docker.sock: permission denied. Are you trying to connect to a TLS-enabled daemon without TLS?
-Starting OpenStack Client Container....
+ :
 FATA[0000] Post http:///var/run/docker.sock/v1.18/containers/create: dial unix /var/run/docker.sock: permission denied. Are you trying to connect to a TLS-enabled daemon without TLS?
+ :
 ```
 
 **Resolution #2**

--- a/images/installer-openstack/root/usr/local/bin/user_setup_casl
+++ b/images/installer-openstack/root/usr/local/bin/user_setup_casl
@@ -1,8 +1,4 @@
 #!/bin/sh
-set -x
-
-chmod g+rw /etc/resolv.conf
-ls -l  /etc/resolv.conf
 
 mkdir -p ${HOME}/.ssh
 chown ${USER_UID}:0 ${HOME}/.ssh


### PR DESCRIPTION
What does this PR do?
Introduces a control host image for use with the AWS CASL installs of OpenShift

How should this be manually tested?
See README for the control host image

Is there a relevant Issue open for this?
resolves #150 

Who would you like to review this?
cc: @redhat-cop/casl @makentenza @day4skiing