### PR TITLE
Adding ability to delete an openshift-applier run

### DIFF
--- a/inventory/sample.osp.example.com.d/inventory/group_vars/seed-hosts.yml
+++ b/inventory/sample.osp.example.com.d/inventory/group_vars/seed-hosts.yml
@@ -29,7 +29,9 @@ openshift_cluster_content:
   - name: "MyApp-development"
     file: "https://raw.githubusercontent.com/redhat-cop/cluster-lifecycle/inception-poc/namespaces/myapp-dev.yml"
 - object: policy
-  content_dir: "{{ inventory_dir }}/../files/policy"
+  content:
+  - name: policy directory
+    file: "{{ inventory_dir }}/../files/policy/"
 - object: builds
   content:
   - name: "cakephp"

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -43,10 +43,12 @@ The `tags` definition is a list of tags that will be processed if the `filter_ta
 
 #### Sourcing a directory with files
 
-You can source a directory composed of static files (without parameters) using `content_dir` instead of defining each file individually. That would look like this:
+You can source a directory composed of static files (without parameters) using `files` instead of defining each file individually. That would look like this:
 ```yaml
 - object: policy
-  content_dir: <dir_with_policy_files>
+  content:
+  - name: directory of files
+    file: <path-to>/directory/
 ```
 In this example above, all of the files in the `<dir_with_policy_files>` directory would get sourced and applied to the cluster (native OpenShift processing).
 
@@ -119,15 +121,18 @@ openshift_cluster_content:
 
 ### Filtering content based on tags
 
-The `openshift-applier` supports the use of tags in the inventory (see example above) to allow for filtering which content should be processed and not. The `filter_tags` variable/fact takes a comma separated list of tags that will be processed and only content/content_dir with matching tags will be applied. 
+The `openshift-applier` supports the use of tags in the inventory (see example above) to allow for filtering which content should be processed and not. The `filter_tags` variable/fact takes a comma separated list of tags that will be processed and only content/content_dir with matching tags will be applied.
 
 **_NOTE:_** Entries in the inventory without tags will not be procssed when a valid list is supplied with the `filter_tags` option.
 
 ```
 filter_tags=tag1,tag2
 
-``` 
+```
 
+### Deprovisioning
+
+The `openshift-applier` role also supports deprovisioning of resources using `file_action: delete` or `template_action: delete`. This can be done either on individual files, if you want to continually ensure objects remain deleted, or it may be done globally using `provision: false`. Using `provision: false` essentially acts like a big 'undo' button, re-running all files and templates through `oc delete -f <resources>`. This can be useful when you want to do a full cleanup to ensure the integrity of you IaC repo, or for simple cleanup while testing changes.
 
 Dependencies
 ------------

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -1,18 +1,36 @@
-openshift-applier
-=================
+# openshift-applier
 
 Role used to apply OpenShift objects to an existing OpenShift Cluster.
 
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-Requirements
-------------
+- [openshift-applier](#openshift-applier)
+	- [Requirements](#requirements)
+	- [Role Usage](#role-usage)
+		- [Sourcing OpenShift Object Definitions](#sourcing-openshift-object-definitions)
+		- [Sourcing a directory with files](#sourcing-a-directory-with-files)
+		- [Ordering of Objects in the inventory](#ordering-of-objects-in-the-inventory)
+		- [Privileged Objects](#privileged-objects)
+		- [Object Entries in the Inventory](#object-entries-in-the-inventory)
+		- [Override default actions with `file_action` and `template_action`](#override-default-actions-with-fileaction-and-templateaction)
+		- [Filtering content based on tags](#filtering-content-based-on-tags)
+		- [Deprovisioning](#deprovisioning)
+		- [Dependencies](#dependencies)
+	- [Example Playbook](#example-playbook)
+	- [License](#license)
+	- [Author Information](#author-information)
+
+<!-- /TOC -->
+
+
+## Requirements
+
 A working OpenShift cluster that can be used to populate things like namespaces, policies and PVs (all require cluster-admin), or application level content.
 
 
-Role Variables
---------------
+## Role Usage
 
-#### Sourcing OpenShift Object Definitions
+### Sourcing OpenShift Object Definitions
 
 The variable definitions come in the form of an object, `openshift_cluster_content`, which contains sub-objects containing file, template, and parameter definitions. At its simplest, this definition looks like this:
 
@@ -41,16 +59,20 @@ You have the choice of sourcing a `file` or a `template`. The `file` definition 
 
 The `tags` definition is a list of tags that will be processed if the `filter_tags` variable/fact is supplied. See [Filtering content based on tags](https://github.com/redhat-cop/casl-ansible/tree/filter/roles/openshift-applier#filtering-content-based-on-tags) below for more details.
 
-#### Sourcing a directory with files
+### Sourcing a directory with files
 
-You can source a directory composed of static files (without parameters) using `files` instead of defining each file individually. That would look like this:
+You can source a directory composed of static files (without parameters) using `files` instead of defining each file individually.
+
+NOTE: Formerly, this was done using a separate `content_dir` structure. This has been deprecated.
+
+That would look like this:
 ```yaml
 - object: policy
   content:
   - name: directory of files
     file: <path-to>/directory/
 ```
-In this example above, all of the files in the `<dir_with_policy_files>` directory would get sourced and applied to the cluster (native OpenShift processing).
+In this example above, all of the files in the `<path-to>/directory/` directory would get sourced and applied to the cluster (native OpenShift processing).
 
 ### Ordering of Objects in the inventory
 
@@ -118,6 +140,7 @@ openshift_cluster_content:
     template_action: create       # Note the template_action set to override the default 'apply' action
 ```
 
+Valid `file_action` and `template_action` values are `apply`, `create`, and `delete`.
 
 ### Filtering content based on tags
 
@@ -132,23 +155,21 @@ filter_tags=tag1,tag2
 
 ### Deprovisioning
 
-The `openshift-applier` role also supports deprovisioning of resources using `file_action: delete` or `template_action: delete`. This can be done either on individual files, if you want to continually ensure objects remain deleted, or it may be done globally using `provision: false`. Using `provision: false` essentially acts like a big 'undo' button, re-running all files and templates through `oc delete -f <resources>`. This can be useful when you want to do a full cleanup to ensure the integrity of you IaC repo, or for simple cleanup while testing changes.
+The `openshift-applier` role also supports global deprovisioning of resources. This can be done either using `provision: false`. Setting `-e provision: false` on a run essentially acts like a big 'undo' button, re-running all files and templates through `oc delete -f <resources>`. This can be useful when you want to do a full cleanup to ensure the integrity of you IaC repo, or for simple cleanup while testing changes.
 
-Dependencies
-------------
+### Dependencies
+
 - openshift-login: Ansible role used to login a user to the OpenShift cluster.
 
 
-Example Playbook
-----------------
+## Example Playbook
 
 TBD
 
-License
--------
+## License
 
 BSD
 
-Author Information
-------------------
+## Author Information
+
 Red Hat Community of Practice & staff of the Red Hat Open Innovation Labs.

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -7,3 +7,4 @@ filter_tags: ''
 file_action: apply
 template_action: apply
 
+provision: True

--- a/roles/openshift-applier/tasks/main.yml
+++ b/roles/openshift-applier/tasks/main.yml
@@ -12,4 +12,4 @@
   loop_control:
     loop_var: entry
   when:
-  - entry.content is defined or entry.content_dir is defined 
+  - entry.content is defined or entry.content_dir is defined

--- a/roles/openshift-applier/tasks/process-content.yml
+++ b/roles/openshift-applier/tasks/process-content.yml
@@ -4,10 +4,3 @@
   include_tasks: process-one-entry.yml
   with_items:
   - "{{ entry.content | default([]) }}"
-
-- name: "Apply OpenShift Cluster Content ('{{ entry.object }}') - based on directory"
-  command: >
-    oc apply -f {{ tmp_inv_dir }}{{ entry.content_dir }}
-  when:
-  - entry.content_dir is defined 
-  - entry.content_dir|trim != ''

--- a/roles/openshift-applier/tasks/process-content.yml
+++ b/roles/openshift-applier/tasks/process-content.yml
@@ -8,7 +8,8 @@
 - name: "Apply OpenShift Cluster Content ('{{ entry.object }}') - based on directory"
   block:
   - fail:
-      msg: "This functionality is being deprecated. Please use the 'content.file' variable instead. See role docs for more info."
+      msg: "WARNING: This functionality is being deprecated. Please use the 'content.file' variable instead. See role docs for more info."
+      ignore_errors: True
   - command: >
       oc apply -f {{ tmp_inv_dir }}{{ entry.content_dir }}
   when:

--- a/roles/openshift-applier/tasks/process-content.yml
+++ b/roles/openshift-applier/tasks/process-content.yml
@@ -4,3 +4,13 @@
   include_tasks: process-one-entry.yml
   with_items:
   - "{{ entry.content | default([]) }}"
+
+- name: "Apply OpenShift Cluster Content ('{{ entry.object }}') - based on directory"
+  block:
+  - fail:
+      msg: "This functionality is being deprecated. Please use the 'content.file' variable instead. See role docs for more info."
+  - command: >
+      oc apply -f {{ tmp_inv_dir }}{{ entry.content_dir }}
+  when:
+  - entry.content_dir is defined
+  - entry.content_dir|trim != ''

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -12,6 +12,13 @@
     params: "{{ item.params | default('') }}"
     process_local: ''
 
+- name: "Set file_action and template_action to delete when in deprovision mode"
+  set_fact:
+    file_action: "delete"
+    template_action: "delete"
+  when:
+  - not provision|bool
+
 - name: "Fail if template but no params is specified"
   fail:
     msg: "Template specified, but no params file supplied"
@@ -44,7 +51,7 @@
 - name: "Set 'file' values (if applicable)"
   set_fact:
     file: "{{ file_path }}"
-    file_f_option: "{{ option_f }}" 
+    file_f_option: "{{ option_f }}"
   when:
   - file|trim != ''
 
@@ -58,7 +65,7 @@
 - name: "Set 'template' values (if applicable)"
   set_fact:
     template: "{{ file_path }}"
-    template_f_option: "{{ option_f }}" 
+    template_f_option: "{{ option_f }}"
   when:
   - template|trim != ''
 
@@ -76,6 +83,7 @@
   failed_when:
   - command_result.rc != 0
   - "'AlreadyExists' not in command_result.stderr"
+  - "'NotFound' not in command_result.stderr"
   when:
   - file|trim != ''
 
@@ -91,6 +99,7 @@
   failed_when:
   - command_result.rc != 0
   - "'AlreadyExists' not in command_result.stderr"
+  - "'NotFound' not in command_result.stderr"
   when:
   - template|trim != ''
   - params|trim != ''


### PR DESCRIPTION
#### What does this PR do?
Adds ability to delete items in an applier run.

#### How should this be manually tested?
Two modes:

Test delete of entire inventory:
```
ansible-playbook -i inventory/ playbooks/openshift-cluster-seed.yml -e "provision=False"
```

Testing delete of individual items:
```
  - name: "my-cakephp-spaces"
    file: "{{ inventory_dir }}/../files/cakephp/ProjectRequest/my-cakephp-spaces.yml"
    file_action: delete
  - name: "projectrequest-test1"
    template: "{{ inventory_dir }}/../files/ProjectRequest/template.yml"
    params: "{{ inventory_dir }}/../files/ProjectRequest/test1.param"
    template_action: delete
```

#### Is there a relevant Issue open for this?
https://github.com/redhat-cop/casl-ansible/issues/143

#### Who would you like to review this?
cc: @redhat-cop/casl
