### PR TITLE
Corrected syntax when running installer-openstack image in README

### DIFF
--- a/images/installer-openstack/README.md
+++ b/images/installer-openstack/README.md
@@ -31,7 +31,7 @@ docker run -u `id -u` \
       -v $HOME/.config/openstack/:/opt/app-root/src/.config/openstack/ \
       -e INVENTORY_DIR=/tmp/src/casl-ansible/inventory/sample.casl.example.com.d/inventory/ \
       -e PLAYBOOK_FILE=/tmp/src/casl-ansible/playbooks/openshift/end-to-end.yml \
-      -e OPTS="-v openstack_ssh_public_key=my-public-key" -t \
+      -e OPTS="-e openstack_ssh_public_key=my-public-key" -t \
       redhatcop/installer-openstack
 ```
 


### PR DESCRIPTION
#### What does this PR do?
Corrects an error in the command to start the `installer-openstack` image 

#### How should this be manually tested?
Review changes in README

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @redhat-cop/casl
