### PR TITLE
Fix the name of the dns public variable to be consistent

### DIFF
--- a/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
@@ -24,9 +24,9 @@ osm_cockpit_plugins:
 os_sdn_network_plugin_name: 'redhat/openshift-ovs-multitenant'
 
 # OpenShift FQDNs, DNS, App domain specific configurations
-openshift_master_default_subdomain: "apps.{{ env_id }}.{{ public_dns_domain }}"
-openshift_master_cluster_hostname: "master-0.{{ env_id }}.{{ public_dns_domain }}"
-openshift_master_cluster_public_hostname: "console.{{ env_id }}.{{ public_dns_domain }}"
+openshift_master_default_subdomain: "apps.{{ env_id }}.{{ dns_domain }}"
+openshift_master_cluster_hostname: "master-0.{{ env_id }}.{{ dns_domain }}"
+openshift_master_cluster_public_hostname: "console.{{ env_id }}.{{ dns_domain }}"
 
 # Change default ports to use standard 443
 openshift_master_api_port: 443


### PR DESCRIPTION
#### What does this PR do?
This PR changes the name used for the DNS domain variable in `OSEv3.yml` file to be consistent with the name of the same var in `all.yml` file.

#### How should this be manually tested?
Follow the instructions in the README

#### Is there a relevant Issue open for this?
This PR solves #158 

#### Who would you like to review this?
cc: @redhat-cop/casl
