### PR TITLE
Add requirements.yml file to support Galaxy from Ansible Tower

### DIFF
--- a/casl-requirements.yml
+++ b/casl-requirements.yml
@@ -1,6 +1,6 @@
-
 # This is the Ansible Galaxy requirements file to pull in the correct roles
 # to support the operation of CASL provisioning/runs.
+# and also support any role dependency while using the repository in Ansible Tower
 
 # From 'infra-ansible'
 - src: https://github.com/redhat-cop/infra-ansible

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,0 +1,12 @@
+# Requirements file to support Ansible Galaxy from Ansible Tower project updates
+
+# From 'infra-ansible'
+- src: https://github.com/redhat-cop/infra-ansible
+
+# From 'openshift-ansible-contrib'
+- src: https://github.com/openshift/openshift-ansible-contrib
+  version: v3.7.0
+
+# From 'openshift-ansible'
+- src: https://github.com/openshift/openshift-ansible
+  version: release-3.7

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,12 +1,1 @@
-# Requirements file to support Ansible Galaxy from Ansible Tower project updates
-
-# From 'infra-ansible'
-- src: https://github.com/redhat-cop/infra-ansible
-
-# From 'openshift-ansible-contrib'
-- src: https://github.com/openshift/openshift-ansible-contrib
-  version: v3.7.0
-
-# From 'openshift-ansible'
-- src: https://github.com/openshift/openshift-ansible
-  version: release-3.7
+../casl-requirements.yml


### PR DESCRIPTION
#### What does this PR do?
Add the required file 'requirements.yml' under roles directory to support Galaxy to pull required roles from Tower automatically on project update.

http://docs.ansible.com/ansible-tower/latest/html/userguide/projects.html#ansible-galaxy-support

#### How should this be manually tested?
Create a project in Tower using CASL repository and check roles under 'requirements.yml' are pulled after project update.

#### Is there a relevant Issue open for this?
No
#### Who would you like to review this?
cc: @redhat-cop/casl
