### PR TITLE
Improved URL checking for openshift-applier

### DIFF
--- a/roles/openshift-applier/tasks/check-file-location.yml
+++ b/roles/openshift-applier/tasks/check-file-location.yml
@@ -8,24 +8,26 @@
 - name: "Check if the passed in path is a remote location (URL)"
   uri:
     url: "{{ path }}"
+    method: HEAD
+  failed_when: false
   register: url_result
-  failed_when:
-  - '"unknown url" not in url_result.msg and url_result.url is not defined'
 
 - name: "Check if passed in path is a local file (if not remote location)"
   stat:
     path: "{{ tmp_inv_dir }}{{ path }}"
-  ignore_errors: yes
+  failed_when: false
   register: file_result
   when:
-  - '"unknown url" in url_result.msg or (url_result.status is defined and url_result.status != 200)'
+  - (url_result.status is undefined) or
+    (url_result.status is defined and url_result.status != 200)
 
 - name: "Set the '-f' option if the template is either a remote or local file"
   set_fact:
     option_f: ' -f '
     process_local: ' --local '
   when:
-  - '"unknown url" not in url_result.msg or file_result.stat.exists'
+  - (url_result.status is defined and url_result.status == 200) or
+    (file_result.stat.exists)
 
 - name: "Pre-pend the temporary dir if the file exists at the local location"
   set_fact:

--- a/roles/openshift-applier/tasks/check-file-location.yml
+++ b/roles/openshift-applier/tasks/check-file-location.yml
@@ -9,7 +9,9 @@
   uri:
     url: "{{ path }}"
     method: HEAD
-  failed_when: false
+  failed_when:
+  - url_result.status is defined
+  - url_result.status == -1
   register: url_result
 
 - name: "Check if passed in path is a local file (if not remote location)"


### PR DESCRIPTION
#### What does this PR do?
This PR enhances how URLs are checked to avoid "false positives" on an entry being a URL. 

#### How should this be manually tested?
Run the `openshift-applier` with an inventory that have all of the following types for templates:
- local file
- URL 
- OpenShift existing template
... the `seed_hosts` content found in the `sample.osp.example.com.d` inventory should meet this requirement. 

#### Is there a relevant Issue open for this?
Resolves #171 

#### Who would you like to review this?
cc: @redhat-cop/casl
