### PR TITLE
Merge fix for display name of tasks

### DIFF
--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -83,7 +83,7 @@
   loop_control:
     loop_var: step
 
-- name: "Create OpenShift objects based on static files for '{{ content.name | default(entry.object) }}'"
+- name: "Create OpenShift objects based on static files for '{{ entry.object}} : {{ content.name | default(file | basename) }}'"
   command: >
     oc {{ file_action }} {{ target_namespace }} -f {{ file }}
   register: command_result
@@ -94,7 +94,7 @@
   when:
   - file|trim != ''
 
-- name: "Create OpenShift objects based on template with params for '{{ content.name | default(entry.object) }}'"
+- name: "Create OpenShift objects based on template with params for '{{ entry.object}} : {{ content.name | default(template | basename) }}'"
   shell: >
     oc process \
       {{ process_local }} \

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -83,7 +83,7 @@
   loop_control:
     loop_var: step
 
-- name: "Create OpenShift objects based on static files for '{{ item.name | default(entry.object) }}'"
+- name: "Create OpenShift objects based on static files for '{{ content.name | default(entry.object) }}'"
   command: >
     oc {{ file_action }} {{ target_namespace }} -f {{ file }}
   register: command_result
@@ -94,7 +94,7 @@
   when:
   - file|trim != ''
 
-- name: "Create OpenShift objects based on template with params for '{{ item.name | default(entry.object) }}'"
+- name: "Create OpenShift objects based on template with params for '{{ content.name | default(entry.object) }}'"
   shell: >
     oc process \
       {{ process_local }} \


### PR DESCRIPTION
#### What does this PR do?
Fixing a merge issue where `item` changed to `content` + improving the displayed message

#### How should this be manually tested?
Run with an inventory that has a `name` entry as well an entry without the `name` entry

#### Is there a relevant Issue open for this?
resolves #180 

#### Who would you like to review this?
cc: @redhat-cop/casl
