### PR TITLE
Chaning failed_when logic so it only ignores 'NotFound' errors when *…

### DIFF
--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -88,9 +88,8 @@
     oc {{ file_action }} {{ target_namespace }} -f {{ file }}
   register: command_result
   failed_when:
-  - command_result.rc != 0
-  - "'AlreadyExists' not in command_result.stderr"
-  - "'NotFound' not in command_result.stderr"
+    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' not in command_result.stderr) or
+    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' in command_result.stderr and file_action != 'delete')
   when:
   - file|trim != ''
 
@@ -104,9 +103,8 @@
     oc {{ template_action }} {{ target_namespace }} -f -
   register: command_result
   failed_when:
-  - command_result.rc != 0
-  - "'AlreadyExists' not in command_result.stderr"
-  - "'NotFound' not in command_result.stderr"
+    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' not in command_result.stderr) or
+    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' in command_result.stderr and template_action != 'delete')
   when:
   - template|trim != ''
   - params|trim != ''

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -85,11 +85,11 @@
 
 - name: "Create OpenShift objects based on static files for '{{ entry.object}} : {{ content.name | default(file | basename) }}'"
   command: >
-    oc {{ file_action }} {{ target_namespace }} -f {{ file }}
+    oc {{ file_action }} {{ target_namespace }} -f {{ file }} {{ (file_action == 'delete') | ternary('--ignore-not-found', '') }}
   register: command_result
   failed_when:
-    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' not in command_result.stderr) or
-    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' in command_result.stderr and file_action != 'delete')
+  - command_result.rc != 0
+  - "'AlreadyExists' not in command_result.stderr"
   when:
   - file|trim != ''
 
@@ -100,11 +100,11 @@
       {{ template_f_option }} {{ template }} \
       {{ target_namespace }} \
       --param-file={{ tmp_inv_dir }}{{ content.params }} | \
-    oc {{ template_action }} {{ target_namespace }} -f -
+    oc {{ template_action }} {{ target_namespace }} -f - {{ (template_action == 'delete') | ternary('--ignore-not-found', '') }}
   register: command_result
   failed_when:
-    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' not in command_result.stderr) or
-    (command_result.rc != 0 and 'AlreadyExists' not in command_result.stderr and 'NotFound' in command_result.stderr and template_action != 'delete')
+  - command_result.rc != 0
+  - "'AlreadyExists' not in command_result.stderr"
   when:
   - template|trim != ''
   - params|trim != ''

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -83,7 +83,7 @@
   loop_control:
     loop_var: step
 
-- name: "Create OpenShift objects based on static files for '{{ entry.object}} : {{ content.name | default(file | basename) }}'"
+- name: "{{ file_action | capitalize }} OpenShift objects based on static files for '{{ entry.object}} : {{ content.name | default(file | basename) }}'"
   command: >
     oc {{ file_action }} {{ target_namespace }} -f {{ file }} {{ (file_action == 'delete') | ternary('--ignore-not-found', '') }}
   register: command_result
@@ -93,7 +93,7 @@
   when:
   - file|trim != ''
 
-- name: "Create OpenShift objects based on template with params for '{{ entry.object}} : {{ content.name | default(template | basename) }}'"
+- name: "{{ template_action | capitalize }} OpenShift objects based on template with params for '{{ entry.object}} : {{ content.name | default(template | basename) }}'"
   shell: >
     oc process \
       {{ process_local }} \

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -85,7 +85,7 @@
 
 - name: "{{ file_action | capitalize }} OpenShift objects based on static files for '{{ entry.object}} : {{ content.name | default(file | basename) }}'"
   command: >
-    oc {{ file_action }} {{ target_namespace }} -f {{ file }} {{ (file_action == 'delete') | ternary('--ignore-not-found', '') }}
+    oc {{ file_action }} {{ target_namespace }} -f {{ file }} {{ (file_action == 'delete') | ternary(' --ignore-not-found', '') }}
   register: command_result
   failed_when:
   - command_result.rc != 0
@@ -100,7 +100,7 @@
       {{ template_f_option }} {{ template }} \
       {{ target_namespace }} \
       --param-file={{ tmp_inv_dir }}{{ content.params }} | \
-    oc {{ template_action }} {{ target_namespace }} -f - {{ (template_action == 'delete') | ternary('--ignore-not-found', '') }}
+    oc {{ template_action }} {{ target_namespace }} -f - {{ (template_action == 'delete') | ternary(' --ignore-not-found', '') }}
   register: command_result
   failed_when:
   - command_result.rc != 0


### PR DESCRIPTION
…_action=delete

#### What does this PR do?
fixes #184 

#### How should this be manually tested?
I tested using https://github.com/redhat-cop/containers-quickstarts/tree/master/rabbitmq

step 1. run `ansible-playbook -i inventory/ ../casl-ansible/playbooks/openshift-cluster-seed.yml --connection=local`. See that all creates properly.
step 2. delete project `oc delete project rabbitmq`
step 3. comment out the following:
```
#- object: projectrequest
#  content:
#  - name: rabbitmq-spaces
#    file: "{{ inventory_dir }}/../files/projects/projects.yml"
#    file_action: create
```
step 4. run `ansible-playbook -i inventory/ ../casl-ansible/playbooks/openshift-cluster-seed.yml --connection=local`. see that you get an error because the namepsace doesn't exist.
step 5. run `ansible-playbook -i inventory/ ../casl-ansible/playbooks/openshift-cluster-seed.yml --connection=local -e provision=false`. see that all succeeds.
step 6. run `ansible-playbook -i inventory/ ../casl-ansible/playbooks/openshift-cluster-seed.yml --connection=local -e provision=false` again. see that all still succeeds.

#### Is there a relevant Issue open for this?
#184 

#### Who would you like to review this?
cc: @redhat-cop/casl
