### PR TITLE
Fix temp dir handling

### DIFF
--- a/roles/openshift-applier/handlers/main.yml
+++ b/roles/openshift-applier/handlers/main.yml
@@ -1,10 +1,16 @@
 ---
 
-- name: "Clean-up temporary dir"
+- name: "Clean-up temporary inv dir"
   file:
     path: "{{ item }}"
     state: absent
   with_items:
   - "{{ tmp_inv_dir }}"
+
+- name: "Clean-up temporary dep dir"
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
   - "{{ tmp_dep_dir }}"
 

--- a/roles/openshift-applier/tasks/copy-inventory-to-remote.yml
+++ b/roles/openshift-applier/tasks/copy-inventory-to-remote.yml
@@ -5,7 +5,7 @@
     state: directory
   register: tmp_dir
   notify:
-  - Clean-up temporary dir
+  - Clean-up temporary inv dir
 
 - name: "Store away the temporary directory path"
   set_fact:

--- a/roles/openshift-applier/tasks/install-dependencies.yml
+++ b/roles/openshift-applier/tasks/install-dependencies.yml
@@ -5,7 +5,7 @@
     state: directory
   register: tmp_dir
   notify:
-  - Clean-up temporary dir
+  - Clean-up temporary dep dir
   when:
   - tmp_dep_dir is undefined
 


### PR DESCRIPTION
#### What does this PR do?
Fixing temporary dir clean-up - including when pre/post dependencies are not specified

#### How should this be manually tested?
Run an applier inventory with the following conditions:
- without pre/post dependencies specified
- with galaxy dependencies
- with remote target for `seed-hosts`

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
