### PR TITLE
aws-provisioning: add new play to create a CNAME for Master API

### DIFF
--- a/roles/manage-aws-infra/tasks/update_dns.yml
+++ b/roles/manage-aws-infra/tasks/update_dns.yml
@@ -20,6 +20,19 @@
     ttl: 300
   when: not ha_mode
 
+- name: Update Route53 with a CNAME to OCP master API
+  route53:
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    zone: "{{ dns_domain }}."
+    record: "console.{{ env_id }}.{{ dns_domain }}."
+    type: CNAME
+    value: "master-0.{{ env_id }}.{{ dns_domain }}"
+    command: create
+    overwrite: yes
+    ttl: 300
+  when: not ha_mode
+
 - name: Update Route53 with OCP infra wildcard record
   route53:
     aws_access_key: "{{ aws_access_key }}"


### PR DESCRIPTION
#### What does this PR do?
Add a new entry in Route53 to cover the `openshift_master_cluster_public_hostname` variable value.

#### How should this be manually tested?
Deploy AWS cluster following instructions from README

#### Is there a relevant Issue open for this?
resolves #196 

#### Who would you like to review this?
cc: @redhat-cop/casl
