### PR TITLE
Add support for applying templates with a directory of parameter files

### DIFF
--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -108,6 +108,26 @@
   when:
   - template|trim != ''
   - params|trim != ''
+  - not params_result.stat.isdir
+
+- name: "{{ template_action | capitalize }} OpenShift objects based on template with params for '{{ entry.object}} : {{ content.name | default(template | basename) }}'"
+  shell: >
+    oc process \
+      {{ process_local }} \
+      {{ template_f_option }} {{ template }} \
+      {{ target_namespace }} \
+      --param-file={{ item }} | \
+    oc {{ template_action }} {{ target_namespace }} -f - {{ (template_action == 'delete') | ternary(' --ignore-not-found', '') }}
+  register: command_result
+  failed_when:
+  - command_result.rc != 0
+  - "'AlreadyExists' not in command_result.stderr"
+  with_fileglob:
+  - "{{ tmp_inv_dir }}{{ content.params }}/*"
+  when:
+  - template|trim != ''
+  - params|trim != ''
+  - params_result.stat.isdir
 
 - name: "Include any post-processing role(s) after applying file and/or template"
   include: pre-post-step.yml


### PR DESCRIPTION
#### What does this PR do?
See title 

#### How should this be manually tested?

Template:

```
$ cat applier/templates/sbx-project.yml 
apiVersion: v1
kind: Template
labels:
  template: sandbox-project
metadata:
  annotations:
  name: sandbox-project
objects:
- kind: ProjectRequest
  apiVersion: v1
  metadata:
    name: sbx-${USERNAME}
    creationTimestam: null
  displayName: Sanbox Project for ${USERNAME}
parameters:
- description: The user for which we are creating the sandbox project
  name: USERNAME
  required: true
```

Vars file

```
$ cat applier/inventory/group_vars/seed-hosts.yml
openshift_cluster_content:
- object: Manage Sandbox Projects
  content:
  - name: "Ensure Projects are Created"
    template: "{{ inventory_dir }}/../templates/sbx-project.yml"
    params: "{{ inventory_dir }}/../params/sandboxes/"
    template_action: create
```

Create directory with multiple params files

```
$ grep '' applier/params/sandboxes/*
applier/params/sandboxes/esauer:USERNAME=esauer
applier/params/sandboxes/jhuddles:USERNAME=jhuddles
```

And run:

```
ansible-playbook -i applier/inventory/ ../casl-ansible/playbooks/openshift-cluster-seed.yml
```
#### Is there a relevant Issue open for this?
resolves #195 

#### Who would you like to review this?
cc: @redhat-cop/casl
