### PR TITLE
openshift-applier: add pre/post task waiting for Openshift route status

### DIFF
--- a/roles/openshift-route-status/tasks/main.yml
+++ b/roles/openshift-route-status/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+- name: "Lookup route url for {{ route }}"
+  shell: "oc get route {{ route }} -o jsonpath='{ .spec.host }'"
+  register: hostname
+  when:
+  - route is defined
+  - route|trim != ''
+
+- name: "Set default delay time"
+  set_fact:
+    delay: "{{ delay | default(5) }}"
+
+- name: "Set default number of retries"
+  set_fact:
+    retries: "{{ retries | default(3) }}"
+
+- name: "Wait for {{ protocol }}://{{ hostname.stdout }} to respond with status: {{ status }}"
+  uri:
+    url: "{{ protocol }}://{{ hostname.stdout }}"
+  register: rc
+  until: rc.status|trim|int == status|trim|int
+  retries: "{{ retries|int }}"
+  delay: "{{ delay|int }}"
+  when:
+  - hostname.stdout is defined
+  - hostname.stdout|trim != ''
+  - protocol is defined
+  - protocol|trim != ''
+  - status is defined
+  - status|trim != ''

--- a/roles/openshift-route-status/tasks/main.yml
+++ b/roles/openshift-route-status/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: "Lookup route url for {{ route }}"
   shell: "oc get route {{ route }} -o jsonpath='{ .spec.host }'"
-  register: hostname
+  register: url
   when:
   - route is defined
   - route|trim != ''
@@ -15,16 +15,16 @@
   set_fact:
     retries: "{{ retries | default(3) }}"
 
-- name: "Wait for {{ protocol }}://{{ hostname.stdout }} to respond with status: {{ status }}"
+- name: "Wait for {{ protocol }}://{{ url.stdout }} to respond with status: {{ status }}"
   uri:
-    url: "{{ protocol }}://{{ hostname.stdout }}"
+    url: "{{ protocol }}://{{ url.stdout }}"
   register: rc
   until: rc.status|trim|int == status|trim|int
   retries: "{{ retries|int }}"
   delay: "{{ delay|int }}"
   when:
-  - hostname.stdout is defined
-  - hostname.stdout|trim != ''
+  - url.stdout is defined
+  - url.stdout|trim != ''
   - protocol is defined
   - protocol|trim != ''
   - status is defined


### PR DESCRIPTION
#### What does this PR do?
Sometimes it's desirable to make sure a service/application is up and running before deploying a dependency. This PR let's you wait for a route to respond with a defined status before continuing.

#### How should this be manually tested?
Here's an example of making sure Sonarqube is responding with status code `200` before deploying Jenkins.
```
---
openshift_cluster_content:
- galaxy_requirements:
  - "{{ inventory_dir }}/../requirements.yml"
- object: projectrequest
  content:
  - name: basic-python-flask-spaces
    file: "{{ inventory_dir }}/../files/projects/projects.yml"
    file_action: create
- object: builds
  content:
  - name: jenkins-slave-python
    template: "{{ inventory_dir }}/../files/builds/jenkins-slave-template.yml"
    params: "{{ inventory_dir }}/../files/builds/jenkins-slave/params"
- object: deployments
  content:
  - name: postgresql
    namespace: basic-python-flask-build
    template: openshift//postgresql-persistent
    params: "{{ inventory_dir }}/../files/deployments/postgresql/params"
  - name: sonarqube
    namespace: basic-python-flask-build
    template: https://raw.githubusercontent.com/rht-labs/labs-ci-cd/master/openshift-templates/sonarqube/template.json
    params: "{{ inventory_dir }}/../files/deployments/sonar/params"
  - name: jenkins
    pre_steps:
    - role: casl-ansible/roles/openshift-route-status
      vars:
        delay: 5
        protocol: http
        retries: 60
        route: sonarqube
        status: 200
    namespace: basic-python-flask-build
    template: "{{ inventory_dir }}/../files/deployments/jenkins.yml"
    params: "{{ inventory_dir }}/../files/deployments/build/params"
```

#### Is there a relevant Issue open for this?
Not that I'm aware of

#### Who would you like to review this?
cc: @redhat-cop/casl
