### PR TITLE
Moving OSP client to OSP12 version

### DIFF
--- a/images/installer-openstack/Dockerfile
+++ b/images/installer-openstack/Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 # Update System and install clients
 RUN yum install -y epel-release; \
-  yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/openstack/openstack-ocata/rdo-release-ocata-3.noarch.rpm; \
+  yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/openstack/openstack-pike/rdo-release-pike-1.noarch.rpm ;\
   yum install -y python-pip python-ceilometerclient \
                  python-cinderclient python-glanceclient \
                  python-heatclient python-neutronclient \


### PR DESCRIPTION
#### What does this PR do?
This is moving the OSP clients to the "Pike" version which aligns with the OSP12 version.

#### How should this be manually tested?
Perform a provisioning with an OSP 12 environment and ensure it's working. Repeat with an older version of OSP as well.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
