### PR TITLE
Fixed 'openshift-applier' and galaxy dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 roles/infra-ansible
 roles/openshift-ansible
 roles/openshift-ansible-contrib
+roles/openshift-applier
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 *.retry
 *.swp
-roles/infra-ansible
-roles/openshift-ansible
-roles/openshift-ansible-contrib
-roles/openshift-applier
+galaxy/
 *.pyc

--- a/casl-requirements.yml
+++ b/casl-requirements.yml
@@ -5,6 +5,10 @@
 # From 'infra-ansible'
 - src: https://github.com/redhat-cop/infra-ansible
 
+# From 'openshift-applier'
+- src: https://github.com/redhat-cop/openshift-applier
+  version: v3.7.2
+
 # From 'openshift-ansible-contrib'
 - src: https://github.com/openshift/openshift-ansible-contrib
   version: v3.7.0

--- a/docs/PROVISIONING_AWS.md
+++ b/docs/PROVISIONING_AWS.md
@@ -19,9 +19,11 @@ git clone https://github.com/redhat-cop/casl-ansible.git
 
 * Run `ansible-galaxy` to pull in the necessary requirements for the CASL provisioning of OpenShift on AWS:
 
+> **NOTE:** The target directory ( `galaxy` ) is **important** as the playbooks know to source roles and playbooks from that location.
+
 ```
 cd ~/src/casl-ansible
-ansible-galaxy install -r casl-requirements.yml -p roles
+ansible-galaxy install -r casl-requirements.yml -p galaxy
 ```
 
 ## AWS specific requirements

--- a/docs/PROVISIONING_OPENSTACK.md
+++ b/docs/PROVISIONING_OPENSTACK.md
@@ -19,9 +19,11 @@ git clone https://github.com/redhat-cop/casl-ansible.git
 
 * Run `ansible-galaxy` to pull in the necessary requirements for the CASL provisioning of OpenShift on OpenStack:
 
+> **NOTE:** The target directory ( `galaxy` ) is **important** as the playbooks know to source roles and playbooks from that location.
+
 ```
 cd ~/src/casl-ansible
-ansible-galaxy install -r casl-requirements.yml -p roles
+ansible-galaxy install -r casl-requirements.yml -p galaxy
 ```
 
 ## OpenStack specific requirements

--- a/playbooks/dns/config_dns_server.yml
+++ b/playbooks/dns/config_dns_server.yml
@@ -7,4 +7,4 @@
     include_vars: vars/views.yml
     delegate_to: localhost
   roles:
-    - role: infra-ansible/roles/dns-server
+    - role: ../../galaxy/infra-ansible/roles/dns-server

--- a/playbooks/nagios/setup_nagios.yml
+++ b/playbooks/nagios/setup_nagios.yml
@@ -2,10 +2,10 @@
 - name: "Set up the nagios targets"
   hosts: nagios-targets
   roles:
-  - role: infra-ansible/roles/nagios-target
+  - role: ../../galaxy/infra-ansible/roles/nagios-target
     
 - name: "Set up nagios server"
   hosts: nagios-servers
   roles:
-  - role: infra-ansible/roles/nagios-server
+  - role: ../../galaxy/infra-ansible/roles/nagios-server
 

--- a/playbooks/openshift/delete-cluster.yml
+++ b/playbooks/openshift/delete-cluster.yml
@@ -2,7 +2,7 @@
 
 #- hosts: seed-hosts
 #  roles:
-#  - openshift-ansible-contrib/roles/openshift-pv-cleanup
+#  - ../../galaxy/openshift-ansible-contrib/roles/openshift-pv-cleanup
 
 - import_playbook: openstack/delete.yml
   when:

--- a/playbooks/openshift/install.yml
+++ b/playbooks/openshift/install.yml
@@ -1,3 +1,3 @@
 ---
 
-- import_playbook: "{{ openshift_ansible_path | default('../../roles/openshift-ansible') }}/playbooks/byo/config.yml"
+- import_playbook: "{{ openshift_ansible_path | default('../../galaxy/openshift-ansible') }}/playbooks/byo/config.yml"

--- a/playbooks/openshift/openstack/cinder-registry.yml
+++ b/playbooks/openshift/openstack/cinder-registry.yml
@@ -9,7 +9,7 @@
       size: "{{ openshift_hosted_registry_storage_volume_size | default(20) }}"
       purpose: "ose_registry"
   roles:
-  - infra-ansible/roles/osp/admin-volume
+  - ../../../galaxy/infra-ansible/roles/osp/admin-volume
 
 - hosts: OSEv3
   tasks:

--- a/playbooks/openshift/openstack/delete.yml
+++ b/playbooks/openshift/openstack/delete.yml
@@ -4,7 +4,7 @@
   pre_tasks:
   - import_tasks: ../prep-inventory.yml
   roles:
-  - role: openshift-ansible-contrib/roles/openstack-stack
+  - role: ../../../galaxy/openshift-ansible-contrib/roles/openstack-stack
     stack_name: "{{ full_dns_domain }}"
     stack_state: 'absent'
   post_tasks:

--- a/playbooks/openshift/openstack/post-provision.yml
+++ b/playbooks/openshift/openstack/post-provision.yml
@@ -5,7 +5,7 @@
   pre_tasks:
     - import_tasks: ../prep-inventory.yml
   roles:
-    - role: openshift-ansible-contrib/roles/hostnames
+    - role: ../../../galaxy/openshift-ansible-contrib/roles/hostnames
 
 # Build and process DNS Records
 - hosts: localhost
@@ -13,7 +13,7 @@
     - import_tasks: ../prep-inventory.yml
     - import_tasks: dns.yml
   roles:
-    - role: infra-ansible/roles/dns
+    - role: ../../../galaxy/infra-ansible/roles/dns
 
 # provision cinder volume
 - import_playbook: cinder-registry.yml

--- a/playbooks/openshift/openstack/provision.yml
+++ b/playbooks/openshift/openstack/provision.yml
@@ -3,7 +3,7 @@
   pre_tasks:
   - import_tasks: ../prep-inventory.yml
   roles:
-  - role: openshift-ansible-contrib/roles/openstack-stack
+  - role: ../../../galaxy/openshift-ansible-contrib/roles/openstack-stack
     stack_name: "{{ env_id }}.{{ dns_domain }}"
     subnet_prefix: "{{ openstack_subnet_prefix }}"
     ssh_public_key: "{{ openstack_ssh_public_key }}"

--- a/playbooks/openshift/post-install.yml
+++ b/playbooks/openshift/post-install.yml
@@ -8,6 +8,6 @@
   roles:
   - { role: create_users }
 
-- import_playbook: ../openshift-cluster-seed.yml
+- import_playbook: roles/openshift-applier/playbooks/openshift-cluster-seed.yml
   when:
   - openshift_cluster_content is defined

--- a/playbooks/openshift/post-install.yml
+++ b/playbooks/openshift/post-install.yml
@@ -8,6 +8,6 @@
   roles:
   - { role: create_users }
 
-- import_playbook: roles/openshift-applier/playbooks/openshift-cluster-seed.yml
+- import_playbook: ../../galaxy/openshift-applier/playbooks/openshift-cluster-seed.yml
   when:
   - openshift_cluster_content is defined

--- a/playbooks/openshift/pre-install.yml
+++ b/playbooks/openshift/pre-install.yml
@@ -15,9 +15,9 @@
 #
 - hosts: OSEv3
   roles:
-    - { role: openshift-ansible-contrib/roles/subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
-    - { role: openshift-ansible-contrib/roles/docker, tags: 'docker' }
-    - { role: openshift-ansible-contrib/roles/openshift-prep, tags: 'openshift-prep' }
+    - { role: ../../galaxy/openshift-ansible-contrib/roles/subscription-manager, when: hostvars.localhost.rhsm_register, tags: 'subscription-manager', ansible_sudo: true }
+    - { role: ../../galaxy/openshift-ansible-contrib/roles/docker, tags: 'docker' }
+    - { role: ../../galaxy/openshift-ansible-contrib/roles/openshift-prep, tags: 'openshift-prep' }
 
 # Ensure the CNS / glusterFS facts are correctly populated for all CNS nodes
 - hosts: glusterfs


### PR DESCRIPTION
#### What does this PR do?
Since the `openshift-applier` moved to a separate repo, we needed to update the playbooks to call the correct one (pulled by galaxy). However, since there's already a roles directory called `openshift-applier`, we had to move the location of the galaxy pulled dependencies - i.e.: moved from `roles/` to `galaxy/`. This PR reflects this change. 

#### How should this be manually tested?
Use the documentation to perform a provisioning.

#### Is there a relevant Issue open for this?
resolves #208

#### Who would you like to review this?
cc: @redhat-cop/casl
