### PR TITLE
Minor restructure of OSP playbooks

### DIFF
--- a/playbooks/openshift/openstack/post-provision.yml
+++ b/playbooks/openshift/openstack/post-provision.yml
@@ -4,6 +4,14 @@
 - hosts: cluster_hosts
   pre_tasks:
     - import_tasks: ../prep-inventory.yml
+    - import_tasks: prep-env.yml
+  tasks:
+    - name: "Set required inventory variables based on the dynamic inventory"
+      set_fact:
+        private_v4: "{{ openstack.private_v4 }}"
+        public_v4: "{{ openstack.public_v4 }}"
+        openshift_hostname: "{{ inventory_hostname }}"
+        openshift_public_hostname: "{{ inventory_hostname }}"
   roles:
     - role: ../../../galaxy/openshift-ansible-contrib/roles/hostnames
 

--- a/playbooks/openshift/openstack/provision.yml
+++ b/playbooks/openshift/openstack/provision.yml
@@ -43,14 +43,5 @@
         name: ../../../galaxy/infra-ansible/roles/update-host
         tasks_from: wait-for-host
 
-- hosts: cluster_hosts
-  tasks:
-    - name: "Set required inventory variables based on the dynamic inventory"
-      set_fact:
-        private_v4: "{{ openstack.private_v4 }}"
-        public_v4: "{{ openstack.public_v4 }}"
-        openshift_hostname: "{{ inventory_hostname }}"
-        openshift_public_hostname: "{{ inventory_hostname }}"
-
 - import_playbook: post-provision.yml
 


### PR DESCRIPTION
#### What does this PR do?
In order to run the `post-provision.yml` playbook as a **standalone** playbook (post initial provisioning), the required variables are being moved from the `provision` to `post-provision` playbook. 

#### How should this be manually tested?
1. Provision a new OpenShift cluster on OpenStack with the `end-to-end.yml` playbook - verify that it works
2. After step 1 has completed successfully, use the `post-provision.yml` playbook to validate that it can be executed without issues. 

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
