### PR TITLE
Fixing a few OSP related issues

### DIFF
--- a/inventory/scripts/openstack.py
+++ b/inventory/scripts/openstack.py
@@ -158,7 +158,11 @@ def get_host_groups_from_cloud(inventory):
 
         if 'interface_ip' not in server:
             continue
-        firstpass[server['name']].append(server)
+        try:
+          if server["metadata"][os.environ['OS_INV_FILTER_KEY']] == os.environ['OS_INV_FILTER_VALUE']:
+            firstpass[server['name']].append(server)
+        except:
+          firstpass[server['name']].append(server)
     for name, servers in firstpass.items():
         if len(servers) == 1 and use_hostnames:
             append_hostvars(hostvars, groups, name, servers[0])

--- a/inventory/scripts/openstack.py
+++ b/inventory/scripts/openstack.py
@@ -158,11 +158,7 @@ def get_host_groups_from_cloud(inventory):
 
         if 'interface_ip' not in server:
             continue
-        try:
-          if server["metadata"][os.environ['OS_INV_FILTER_KEY']] == os.environ['OS_INV_FILTER_VALUE']:
-            firstpass[server['name']].append(server)
-        except:
-          firstpass[server['name']].append(server)
+        firstpass[server['name']].append(server)
     for name, servers in firstpass.items():
         if len(servers) == 1 and use_hostnames:
             append_hostvars(hostvars, groups, name, servers[0])

--- a/playbooks/openshift/openstack/dns-records.yml
+++ b/playbooks/openshift/openstack/dns-records.yml
@@ -57,12 +57,12 @@
     a_records: "{{ a_records | default([]) +
                    [{
                       'type': 'A',
-                      'hostname': (openshift_master_cluster_public_hostname | replace(nsupdate_zone, ''))[:-1],
+                      'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone, ''))[:-1],
                       'ip': master_ip
                    }]
                 }}"
   when:
-    - openshift_master_cluster_public_hostname is defined
+    - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
 
 - name: "Generate the Add section for DNS for all nsupdate servers"
   set_fact:

--- a/roles/create_users/tasks/create_users.yml
+++ b/roles/create_users/tasks/create_users.yml
@@ -1,12 +1,26 @@
 ---
 
- - name: "Create {{ users.num_users }} htpasswd users"
-   htpasswd:
-     path: "{{ users.passwd_file }}"
-     name: "{{ item }}"
-     password: "{{ users.password }}"
-     owner: root
-     group: root
-     mode: 0600
-   with_sequence: start=0 end="{{ users.num_users }}" format="{{ users.prefix }}%02d"
+- name: 'Install required packages'
+  package:
+    name: '{{ item }}'
+    state: installed
+  with_items:
+  - python-passlib
+
+- name: "Use the create_users inventory info"
+  set_fact:
+    users: "{{ create_users }}"
+
+- name: "Create {{ users.num_users }} htpasswd users"
+  htpasswd:
+    path: "{{ users.passwd_file }}"
+    name: "{{ item }}"
+    password: "{{ users.password }}"
+    owner: root
+    group: root
+    mode: 0600
+  with_sequence:
+    start: 0
+    end: "{{ users.num_users }}"
+    format: "{{ users.prefix }}%02d"
 

--- a/roles/create_users/tasks/main.yml
+++ b/roles/create_users/tasks/main.yml
@@ -1,21 +1,6 @@
 ---
 
- - name: 'Install required packages'
-   package:
-     name: '{{ item }}'
-     state: installed
-   with_items:
-   - python-passlib
-
- - name: "Initialize create_users facts"
-   set_fact:
-     users: ''
-
- - name: "Take create_users input when defined"
-   set_fact:
-     users: "{{ create_users }}"
-   when: create_users is defined
-
- - include_tasks: create_users.yml
-   static: no
-   when: create_users is defined
+- include_tasks: create_users.yml
+  static: no
+  when:
+  - create_users is defined


### PR DESCRIPTION
#### What does this PR do?
2 fixes:
- The `openshift_master_cluster_public_hostname` isn't set in the external DNS server
- The create_users processes prereqs even if no users are being added

#### How should this be manually tested?
Run a provisioning in an environment with already existing hosts - make sure it only targets *your* cluster. After installation is done, validate that the `openshift_master_cluster_public_hostname` value is resolvable. 

#### Is there a relevant Issue open for this?
resolves #244 
resolves #243 

#### Who would you like to review this?
cc: @redhat-cop/casl
