### PR TITLE
Add markdown yml codeblock for the cloud_infrastructure skeleton

### DIFF
--- a/roles/manage-aws-infra/README.md
+++ b/roles/manage-aws-infra/README.md
@@ -20,6 +20,7 @@ Many of these required variables have default values. These are the **mandatory*
 Infrastructure skeleton variables
 ---------------------------------
 
+```yaml
 cloud_infrastructure: **mandatory**
    region: **mandatory**
    image_name: **mandatory**
@@ -64,6 +65,7 @@ cloud_infrastructure: **mandatory**
      root_volume_size: **defaulted**
      docker_volume_size: **defaulted**
      gluster_volume_size: **defaulted**
+```
 
 Other variables
 ---------------


### PR DESCRIPTION
#### What does this PR do?
Add a codeblock markdown structure for the `cloud_infrastructure` requirements definition on the role README file, solving the actual syntax as the output is not legible.

#### How should this be manually tested?
Review the README output for legible instructions

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @redhat-cop/casl
