### PR TITLE
Add required port for Prometheus to sample inventories

### DIFF
--- a/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
@@ -90,3 +90,10 @@ openshift_node_kubelet_args:
   - '80'
   image-gc-low-threshold:
   - '60'
+
+# Open required ports on IPTables for Prometheus Node Exporters & Router Statistics
+openshift_node_open_ports:
+  - service: "router stats port"
+    port: "1936/tcp"
+  - service: "prometheus node exporter"
+    port: "9100/tcp"

--- a/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
@@ -44,3 +44,10 @@ osm_cluster_network_cidr: 10.1.0.0/16
 
 openshift_hosted_prometheus_deploy: false
 openshift_cfme_install_app: false
+
+# Open required ports on IPTables for Prometheus Node Exporters & Router Statistics
+openshift_node_open_ports:
+  - service: "router stats port"
+    port: "1936/tcp"
+  - service: "prometheus node exporter"
+    port: "9100/tcp"

--- a/inventory/sample.gcp.example.com.d/inventory/group_vars/infra_hosts.yml
+++ b/inventory/sample.gcp.example.com.d/inventory/group_vars/infra_hosts.yml
@@ -5,4 +5,6 @@ openshift_node_labels:
   
 openshift_node_open_ports:
   - service: "router stats port"
-    port: "1936/tcp"    
+    port: "1936/tcp"
+  - service: "prometheus node exporter"
+    port: "9100/tcp"    

--- a/inventory/sample.gcp.example.com.d/inventory/group_vars/nodes.yaml
+++ b/inventory/sample.gcp.example.com.d/inventory/group_vars/nodes.yaml
@@ -3,6 +3,10 @@
 openshift_node_labels: 
   region: primary
 
+openshift_node_open_ports:
+  - service: "prometheus node exporter"
+    port: "9100/tcp"
+
 openshift_node_kubelet_args:
   kube-reserved: 
   - cpu={{ ansible_processor_vcpus * 50 }}m

--- a/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
@@ -89,3 +89,10 @@ openshift_node_kubelet_args:
   - '80'
   image-gc-low-threshold:
   - '60'
+
+# Open required ports on IPTables for Prometheus Node Exporters & Router Statistics
+openshift_node_open_ports:
+  - service: "router stats port"
+    port: "1936/tcp"
+  - service: "prometheus node exporter"
+    port: "9100/tcp"


### PR DESCRIPTION
#### What does this PR do?
Add the required ports that need to be opened on the OS side to support Prometheus monitoring using Node Exporter

#### How should this be manually tested?
Follow instructions from README, deploy Prometheus and Node Exporter and check Node Exporter targets and HAProxy are working

#### Is there a relevant Issue open for this?
Resolves #263 
#### Who would you like to review this?
cc: @redhat-cop/casl
