### PR TITLE
Remove not required openshift-applier directory

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -1,2 +1,0 @@
-# openshift-applier
-This content has been moved to https://github.com/redhat-cop/openshift-applier


### PR DESCRIPTION
#### What does this PR do?
Remove the old role directory 'openshift-applier' from roles directory. As this role is also included on the requirements for CASL, the existence of the directory is causing Tasks in Ansible Tower to fail as the directory already exists.

#### How should this be manually tested?
Add a new project in Tower based in CASL and create a job template using this project. Once solved the pre-task updating the info from the repository it must not fail

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @redhat-cop/casl
