### PR TITLE
Moving roles from the 'openshift-applier' to this repo

### DIFF
--- a/roles/openshift-labels/README.md
+++ b/roles/openshift-labels/README.md
@@ -1,4 +1,3 @@
 # openshift-labels
 
-This content has been moved to https://github.com/redhat-cop/openshift-applier
 

--- a/roles/openshift-labels/tasks/main.yml
+++ b/roles/openshift-labels/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+- name: "Set defaults"
+  set_fact:
+    target_namespace: "{{ target_namespace | default('') }}"
+
+- name: "Apply label {{ label }} to object {{ target_object }}"
+  command: >
+    oc label --overwrite {{ target_object }} {{ target_name }} {{ label }} {{ target_namespace }}
+  when:
+  - target_object is defined
+  - target_object|trim != ''
+  - target_name is defined
+  - target_name|trim != ''
+  - label is defined
+  - label| trim != ''

--- a/roles/openshift-replicas-ready/defaults/main.yml
+++ b/roles/openshift-replicas-ready/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+target_namespace: ''
+delay: 10
+retries: 30

--- a/roles/openshift-replicas-ready/tasks/main.yml
+++ b/roles/openshift-replicas-ready/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Verify Required Parameters
+  fail:
+    msg: "'resource' and 'type' Parameters Must be Provided!"
+  when: type is not defined or type|trim == '' or resource is not defined or resource|trim == ''
+
+- name: "Set the target namespace option if supplied"
+  set_fact:
+    target_namespace: "-n {{ namespace }}"
+  when:
+  - namespace is defined
+  - namespace|trim != ''
+
+- name: Query Replica Status
+  command: >
+    oc get {{ type }}/{{ resource }} {{ target_namespace }} -o json
+  register: query_result
+  delay: "{{ delay }}"
+  retries: "{{ retries }}"
+  until: (query_result.stdout | from_json)['spec']['replicas'] | default("0") | int == (query_result.stdout | from_json)['status']['readyReplicas'] | default("0") | int
+  failed_when: (query_result.stdout | from_json)['spec']['replicas'] is not defined

--- a/roles/openshift-route-status/README.md
+++ b/roles/openshift-route-status/README.md
@@ -1,4 +1,3 @@
 # openshift-route-status
 
-This content has been moved to https://github.com/redhat-cop/openshift-applier
 

--- a/roles/openshift-route-status/tasks/main.yml
+++ b/roles/openshift-route-status/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+- name: "Lookup route url for {{ route }}"
+  shell: "oc get route {{ route }} -o jsonpath='{ .spec.host }'"
+  register: url
+  when:
+  - route is defined
+  - route|trim != ''
+
+- name: "Set default delay time"
+  set_fact:
+    delay: "{{ delay | default(5) }}"
+
+- name: "Set default number of retries"
+  set_fact:
+    retries: "{{ retries | default(3) }}"
+
+- name: "Wait for {{ protocol }}://{{ url.stdout }} to respond with status: {{ status }}"
+  uri:
+    url: "{{ protocol }}://{{ url.stdout }}"
+  register: rc
+  until: rc.status|trim|int == status|trim|int
+  retries: "{{ retries|int }}"
+  delay: "{{ delay|int }}"
+  when:
+  - url.stdout is defined
+  - url.stdout|trim != ''
+  - protocol is defined
+  - protocol|trim != ''
+  - status is defined
+  - status|trim != ''


### PR DESCRIPTION
#### What does this PR do?
Supporting roles used by the [openshift-applier](https://github.com/redhat-cop/openshift-applier) are now being moved (back) to this repo as it's a better fit for these *generic* roles. 

The corresponding 'clean-up' is done in the openshift-applier PR https://github.com/redhat-cop/openshift-applier/pull/33

#### How should this be manually tested?
Just moving roles

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
