### PR TITLE
Prompt user prior to deleting cluster

### DIFF
--- a/playbooks/openshift/aws/delete.yml
+++ b/playbooks/openshift/aws/delete.yml
@@ -1,4 +1,7 @@
 ---
 - hosts: localhost
+  pre_tasks:
+    - meta: end_play
+      when: not delete_cluster
   roles:
     - { role: manage-aws-infra, action: 'absent' }

--- a/playbooks/openshift/delete-cluster.yml
+++ b/playbooks/openshift/delete-cluster.yml
@@ -4,6 +4,17 @@
 #  roles:
 #  - ../../galaxy/openshift-ansible-contrib/roles/openshift-pv-cleanup
 
+- hosts: localhost
+  vars_prompt:
+    name: "delete_cluster"
+    prompt: "Are you sure you want to delete this cluster? (yes/no)"
+    private: no
+  pre_tasks:
+    - set_fact:
+        delete_cluster: "{{ delete_cluster }}"
+    - meta: end_play
+      when: not delete_cluster
+
 - import_playbook: openstack/delete.yml
   when:
   - hosting_infrastructure == 'openstack'

--- a/playbooks/openshift/delete-cluster.yml
+++ b/playbooks/openshift/delete-cluster.yml
@@ -7,7 +7,7 @@
 - hosts: localhost
   vars_prompt:
     name: "delete_cluster"
-    prompt: "Are you sure you want to delete this cluster? (yes/no)"
+    prompt: "Are you sure you want to delete the {{env_id}} cluster ] (yes/no)"
     private: no
   pre_tasks:
     - set_fact:

--- a/playbooks/openshift/gcp/delete.yml
+++ b/playbooks/openshift/gcp/delete.yml
@@ -2,6 +2,9 @@
 
 - hosts: localhost
   connection: local
+  pre_tasks:
+    - meta: end_play
+      when: not delete_cluster
   tasks:
   - name: cleanup
     include_role:

--- a/playbooks/openshift/openstack/delete.yml
+++ b/playbooks/openshift/openstack/delete.yml
@@ -2,6 +2,8 @@
 
 - hosts: localhost
   pre_tasks:
+    - meta: end_play
+      when: not delete_cluster
     - import_tasks: ../prep-inventory.yml
   roles:
     - role: ../../../galaxy/openshift-ansible-contrib/roles/openstack-stack


### PR DESCRIPTION
#### What does this PR do?
This PR prompts a user to check whether they're sure that they want to delete their OCP cluster. It prompts a user for a simple yes/no and then takes appropriate action.

**NOTE:** Currently this is using `meta: end_play` and taking action based on the response. It appears to be taking the desired action in `openstack` and ends the play immediately (so that you don't see a number of skipped tasks). However it doesn't appear to behave the same way when skipping the `aws` branch. It still skips everything as expected, it just happens to print out a bunch of skipped tasks (from the `manage_aws_infra` role) instead of ending the play immediately like it does on the `openstack` branch. We may want to take a look at this (either now / in the future), but this is a more of a style/preference issue than a technical one (outside of figuring out why the two playbooks aren't acting the same).


#### How should this be manually tested?

`ansible-playbook -i /path/to/your_casl_inventory/ /path/to/casl-ansible/playbooks/openshift/delete_cluster.yml`

#### Who would you like to review this?
cc: @redhat-cop/casl @oybed @logandonley @makentenza 
