### PR TITLE
remove rhel-7-fast-datapath-rpms repo

### DIFF
--- a/inventory/s1-ha.osp.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/s1-ha.osp.example.com.d/inventory/group_vars/all.yml
@@ -35,7 +35,6 @@ rhsm_repos:
   - "rhel-7-server-rpms"
   - "rhel-7-server-ose-3.10-rpms"
   - "rhel-7-server-extras-rpms"
-  - "rhel-7-fast-datapath-rpms"
   - "rhel-7-server-ansible-2.4-rpms"
 
 # Keep this to use Red Hat Satellite:

--- a/inventory/sample.aws.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/sample.aws.example.com.d/inventory/group_vars/all.yml
@@ -145,7 +145,6 @@ rhsm_repos:
   - "rhel-7-server-rpms"
   - "rhel-7-server-ose-3.10-rpms"
   - "rhel-7-server-extras-rpms"
-  - "rhel-7-fast-datapath-rpms"
   - "rhel-7-server-ansible-2.4-rpms"
 
 # Uncomment the following to use Red Hat Satellite:

--- a/inventory/sample.byo.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/sample.byo.example.com.d/inventory/group_vars/all.yml
@@ -16,7 +16,6 @@ rhsm_repos:
  - "rhel-7-server-rpms"
  - "rhel-7-server-ose-3.10-rpms"
  - "rhel-7-server-extras-rpms"
- - "rhel-7-fast-datapath-rpms"
 
 
 # Use RHSM username, password and optionally pool:

--- a/inventory/sample.gcp.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/sample.gcp.example.com.d/inventory/group_vars/all.yml
@@ -58,7 +58,6 @@ rhsm_repos:
  - "rhel-7-server-rpms"
  - "rhel-7-server-ose-3.10-rpms"
  - "rhel-7-server-extras-rpms"
- - "rhel-7-fast-datapath-rpms"
  - "rhel-7-server-ansible-2.4-rpms"
 
 # Use RHSM username, password and optionally pool:

--- a/inventory/sample.osp.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/sample.osp.example.com.d/inventory/group_vars/all.yml
@@ -110,7 +110,6 @@ rhsm_repos:
   - "rhel-7-server-rpms"
   - "rhel-7-server-ose-3.10-rpms"
   - "rhel-7-server-extras-rpms"
-  - "rhel-7-fast-datapath-rpms"
   - "rhel-7-server-ansible-2.4-rpms"
   
 # Keep this to use Red Hat Satellite:


### PR DESCRIPTION
It is no longer needed per
https://github.com/openshift/openshift-docs/pull/11565

#### What does this PR do?
Remove rhel-7-fast-datapath-rpms repo

#### How should this be manually tested?
NA

#### Is there a relevant Issue open for this?
No.

#### Who would you like to review this?
cc: @redhat-cop/casl @dstockdreher 
