### PR TITLE
remove filename for htpasswd that no longer works

### DIFF
--- a/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
@@ -24,7 +24,6 @@ openshift_master_identity_providers:
    'login': 'true'
    'challenge': 'true'
    'kind': 'HTPasswdPasswordIdentityProvider'
-   'filename': '/etc/origin/master/htpasswd'
 
 #this will create an admin/admin user
 openshift_master_htpasswd_users:


### PR DESCRIPTION
The ability to specify the path for htpasswd has been removed:
https://github.com/openshift/openshift-ansible/pull/8047

#### What does this PR do?
It removes the 'filename' for htpasswd that no longer works

#### How should this be manually tested?
NA

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @redhat-cop/casl @dstockdreher 
