### PR TITLE
Missing node group name fix

### DIFF
--- a/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
@@ -70,6 +70,15 @@ openshift_node_groups:
     value: [ 'cpu={{ ansible_processor_vcpus * 50 }}m', 'memory={{ ansible_processor_vcpus * 50 }}M' ]
   - key: kubeletArguments.system-reserved
     value: [ 'cpu={{ ansible_processor_vcpus * 50 }}m', 'memory={{ ansible_processor_vcpus * 100 }}M' ]
+- name: node-config-master-infra
+  labels:
+    - 'node-role.kubernetes.io/infra=true'
+    - 'node-role.kubernetes.io/master=true'
+  edits:
+  - key: kubeletArguments.kube-reserved
+    value: [ 'cpu={{ ansible_processor_vcpus * 50 }}m', 'memory={{ ansible_processor_vcpus * 50 }}M' ]
+  - key: kubeletArguments.system-reserved
+    value: [ 'cpu={{ ansible_processor_vcpus * 50 }}m', 'memory={{ ansible_processor_vcpus * 100 }}M' ]
 - name: node-config-compute
   labels:
   - 'node-role.kubernetes.io/compute=true'

--- a/inventory/sample.byo.example.com.d/inventory/hosts
+++ b/inventory/sample.byo.example.com.d/inventory/hosts
@@ -7,9 +7,9 @@ nodes
 etcd
 
 [masters]
-openshift-master-1.c1-ocp.myorg.com ansible_host=openshift-master-1.c1-ocp.myorg.com
-openshift-master-2.c1-ocp.myorg.com ansible_host=openshift-master-2.c1-ocp.myorg.com
-openshift-master-3.c1-ocp.myorg.com ansible_host=openshift-master-3.c1-ocp.myorg.com
+openshift-master-1.c1-ocp.myorg.com ansible_host=openshift-master-1.c1-ocp.myorg.com openshift_node_group_name='node-config-master-infra'
+openshift-master-2.c1-ocp.myorg.com ansible_host=openshift-master-2.c1-ocp.myorg.com openshift_node_group_name='node-config-master-infra'
+openshift-master-3.c1-ocp.myorg.com ansible_host=openshift-master-3.c1-ocp.myorg.com openshift_node_group_name='node-config-master-infra'
 
 [etcd]
 openshift-master-1.c1-ocp.myorg.com ansible_host=openshift-master-1.c1-ocp.myorg.com


### PR DESCRIPTION
#### What does this PR do?
`openshift-ansible` 3.10 installer expects masters to have `openshift_node_group_name='node-config-master-infra'` set. This PR includes the relevant changes to the BYO `hosts` and `group_vars/OSEv3.yml` files in order to successfully complete the tasks.

#### How should this be manually tested?
1. Set infrastructure for 3 masters and use release-3.10 of `openshift-ansible`
2. DO NOT include the changes in this PR
3. Run `ansible-playbook -i /path/to/byo/inventory /path/to/byo/playbook.yml`
4. Note the failure with error:
```
... SNIP additional info prior
Missing openshift_node_group_name entry node-config-master-infra
... SNIP additional info after
```
5. Merge changes from this PR
6. Repeat step 3
7. Note that error does not occur.

#### Is there a relevant Issue open for this?
[This commit](https://github.com/openshift/openshift-ansible/commit/41e4c8dc5b0d47d56b1b7c7e7cbf5dd81b0202c6
) is included in openshift-ansible 3.10.0+ branches as a default fact.
 
#### Who would you like to review this?
cc: @redhat-cop/casl
