### PR TITLE
Update selectors in sample inventories

### DIFF
--- a/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
@@ -26,7 +26,7 @@ containerized: false
 ### OCP version to install
 openshift_release: v3.10
 
-osm_default_node_selector: 'region=primary'
+osm_default_node_selector: 'node-role.kubernetes.io/compute=true'
 osm_use_cockpit: true
 osm_cockpit_plugins:
 - 'cockpit-kubernetes'

--- a/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
@@ -29,10 +29,10 @@ openshift_master_identity_providers:
 openshift_master_htpasswd_users:
   admin: $apr1$7aiANAYb$TOUYVUqnBqBlD5AQEIMYw1
 
-openshift_hosted_router_selector: 'region=infra'
+openshift_hosted_router_selector: 'node-role.kubernetes.io/infra=true'
 openshift_hosted_manage_router: true
 
-osm_default_node_selector: 'region=primary'
+osm_default_node_selector: 'node-role.kubernetes.io/compute=true'
 
 openshift_docker_options: "--log-driver=json-file --log-opt max-size=50m --log-opt max-file=100"
 

--- a/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
@@ -12,7 +12,7 @@ deployment_type: openshift-enterprise
 openshift_deployment_type: openshift-enterprise
 openshift_release: v3.10
 
-osm_default_node_selector: 'region=primary'
+osm_default_node_selector: 'node-role.kubernetes.io/compute=true'
 osm_use_cockpit: true
 osm_cockpit_plugins:
 - 'cockpit-kubernetes'


### PR DESCRIPTION
#### What does this PR do?
This PR updates the sample inventories based on [this comment](https://github.com/redhat-cop/casl-ansible/pull/305#issuecomment-420870093) in [this](https://github.com/redhat-cop/casl-ansible/pull/305) closed PR. It uses the new (OCP 3.10+) convention for selectors in order to reduce confusion. There is also a change to `openshift_hosted_router_selector` in the byo inventory to match the convention included in this PR.

#### How should this be manually tested?
1. Run the associated sample playbooks against their counterpart inventories.
2. Installation should succeed
3. Deploy any sample app on the newly installed cluster, note that the build fails due to no node supplying the default selector.
4. Destroy cluster
5. Merge this PR and re-run installation
6. Installation should succeed
7. Deploy any sample app, note that the build does not fail because the default selector matches the compute nodes.

#### Is there a relevant Issue open for this?
[Closed PR](https://github.com/redhat-cop/casl-ansible/pull/305)
[Relevant comment calling for this update](https://github.com/redhat-cop/casl-ansible/pull/305#issuecomment-420870093)

#### Who would you like to review this?
cc: @redhat-cop/casl
cc: @oybed 
