### PR TITLE
Updates examples with new mandatory var oreg_url, oreg_auth_user and oreg_auth_password.

### DIFF
--- a/inventory/s1-ha.osp.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/s1-ha.osp.example.com.d/inventory/group_vars/OSEv3.yml
@@ -12,6 +12,12 @@ openshift_master_cluster_hostname: "{{ groups.lb.0 }}"
 openshift_master_cluster_public_hostname: "{{ groups.lb.0 }}"
 openshift_master_default_subdomain: "apps.{{ env_id }}.{{ dns_domain }}"
 
+# Registry URL & Credentials
+# For more info: https://access.redhat.com/terms-based-registry/
+oreg_url: 'registry.redhat.io/openshift3/ose-${component}:${version}'
+#oreg_auth_user: "{{ lookup('env', 'OREG_AUTH_USER' )}}"
+#oreg_auth_password: "{{ lookup('env', 'OREG_AUTH_PASSWORD' )}}"
+
 openshift_master_identity_providers:
  - 'name': 'htpasswd_auth'
    'login': 'true'

--- a/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
@@ -40,6 +40,11 @@ openshift_master_default_subdomain: "apps.{{ env_id }}.{{ dns_domain }}"
 openshift_master_cluster_hostname: "console.internal.{{ env_id }}.{{ dns_domain }}"
 openshift_master_cluster_public_hostname: "console.{{ env_id }}.{{ dns_domain }}"
 
+# Registry URL & Credentials
+# For more info: https://access.redhat.com/terms-based-registry/
+oreg_url: 'registry.redhat.io/openshift3/ose-${component}:${version}'
+#oreg_auth_user: "{{ lookup('env', 'OREG_AUTH_USER' )}}"
+#oreg_auth_password: "{{ lookup('env', 'OREG_AUTH_PASSWORD' )}}"
 
 # Deploy Logging with dynamic storage
 #openshift_logging_install_logging: false

--- a/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.byo.example.com.d/inventory/group_vars/OSEv3.yml
@@ -41,6 +41,12 @@ os_sdn_network_plugin_name: 'redhat/openshift-ovs-networkpolicy'
 os_firewall_use_firewalld: true
 osm_cluster_network_cidr: 10.1.0.0/16
 
+# Registry URL & Credentials
+# For more info: https://access.redhat.com/terms-based-registry/
+oreg_url: 'registry.redhat.io/openshift3/ose-${component}:${version}'
+#oreg_auth_user: "{{ lookup('env', 'OREG_AUTH_USER' )}}"
+#oreg_auth_password: "{{ lookup('env', 'OREG_AUTH_PASSWORD' )}}"
+
 openshift_hosted_prometheus_deploy: false
 openshift_cfme_install_app: false
 

--- a/inventory/sample.gcp.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.gcp.example.com.d/inventory/group_vars/OSEv3.yml
@@ -31,6 +31,12 @@ os_sdn_network_plugin_name: 'redhat/openshift-ovs-networkpolicy'
 os_firewall_use_firewalld: true
 osm_cluster_network_cidr: 10.1.0.0/16
 
+# Registry URL & Credentials
+# For more info: https://access.redhat.com/terms-based-registry/
+oreg_url: 'registry.redhat.io/openshift3/ose-${component}:${version}'
+#oreg_auth_user: "{{ lookup('env', 'OREG_AUTH_USER' )}}"
+#oreg_auth_password: "{{ lookup('env', 'OREG_AUTH_PASSWORD' )}}"
+
 openshift_enable_service_catalog: false
 openshift_hosted_prometheus_deploy: false
 openshift_cfme_install_app: false

--- a/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.osp.example.com.d/inventory/group_vars/OSEv3.yml
@@ -25,6 +25,12 @@ openshift_master_default_subdomain: "apps.{{ env_id }}.{{ dns_domain }}"
 openshift_master_cluster_hostname: "master-0.{{ env_id }}.{{ dns_domain }}"
 openshift_master_cluster_public_hostname: "console.{{ env_id }}.{{ dns_domain }}"
 
+# Registry URL & Credentials
+# For more info: https://access.redhat.com/terms-based-registry/
+oreg_url: 'registry.redhat.io/openshift3/ose-${component}:${version}'
+#oreg_auth_user: "{{ lookup('env', 'OREG_AUTH_USER' )}}"
+#oreg_auth_password: "{{ lookup('env', 'OREG_AUTH_PASSWORD' )}}"
+
 # Enable the OpenStack cloud provider for i.e.: dynamic storage with Cinder
 openshift_cloudprovider_kind: openstack
 openshift_cloudprovider_openstack_auth_url: "{{ lookup('env','OCP_OSP_AUTH_URL') }}"


### PR DESCRIPTION
#### What does this PR do?
Adds new mandatory var oreg_url, oreg_auth_user and oreg_auth_password.
Since 3.10 there is a check to validate this vars.
In 3.11, all container images from the new registry.redhat.io will need credentials to be pulled.

#### Who would you like to review this?
cc: @redhat-cop/casl
