### PR TITLE
fixed issue preventing loadbalancer service VIP to serve traffic

### DIFF
--- a/inventory/sample.gcp.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/sample.gcp.example.com.d/inventory/group_vars/all.yml
@@ -97,8 +97,12 @@ openshift_master_default_subdomain: apps.{{ env_id }}.{{ dns_domain }}
 #a unique prefix (unsure for what is used)
 openshift_gcp_prefix: "{{ env_id }}"
 
-#your openshift goocle project
+#your openshift google project
 openshift_gcp_project: "{{ project_id }}"
 
 #whether your deployment is multizone.
 openshift_gcp_multizone: true
+
+#gcp network name in which OCP will be deployed
+openshift_gcp_network_name: default
+

--- a/roles/manage-gcp-infra/templates/openshift-gcloud.yaml.j2
+++ b/roles/manage-gcp-infra/templates/openshift-gcloud.yaml.j2
@@ -43,7 +43,7 @@ resources:
         - https://www.googleapis.com/auth/servicecontrol
       tags:
         items:
-        - {{ gcloud_env }}
+        - {{ gcloud_env }}ocp
         - {{ gcloud_env }}-master
         - {{ gcloud_env }}-node
   type: compute.v1.instanceTemplate
@@ -88,7 +88,7 @@ resources:
         - https://www.googleapis.com/auth/servicecontrol
       tags:
         items:
-        - {{ gcloud_env }}
+        - {{ gcloud_env }}ocp
         - {{ gcloud_env }}-appnode
         - {{ gcloud_env }}-node
   type: compute.v1.instanceTemplate
@@ -133,7 +133,7 @@ resources:
         - https://www.googleapis.com/auth/servicecontrol
       tags:
         items:
-        - {{ gcloud_env }}
+        - {{ gcloud_env }}ocp
         - {{ gcloud_env }}-infranode
         - {{ gcloud_env }}-node
   type: compute.v1.instanceTemplate    


### PR DESCRIPTION
#### What does this PR do?
LoadBalancer type of service will serve traffic to nodes with this tag `<env>ocp` as per here: 
https://docs.openshift.com/container-platform/3.10/install_config/configuring_gce.html#gce-load-balancer_configuring-for-GCE

This PR label the nodes adequately to meet this requirement.

#### How should this be manually tested?
Include commands to run your new feature, and also post-run commands to validate that it worked. 

create an app and a load balancer service and verify that traffic is being served,

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

no.

#### Who would you like to review this?
cc: @redhat-cop/casl
