### PR TITLE
Opened up node exporter port on all OCP hosts

### DIFF
--- a/roles/manage-aws-infra/templates/casl-aws-cformation.yml.j2
+++ b/roles/manage-aws-infra/templates/casl-aws-cformation.yml.j2
@@ -247,6 +247,10 @@ Resources:
         FromPort: '4789'
         ToPort: '4789'
         CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: '9100'
+        ToPort: '9100'
+        CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
       - IpProtocol: '-1'
         FromPort: '-1'


### PR DESCRIPTION
#### What does this PR do?
Opens up node exporter port on all OCP nodes. Needed to support cluster monitoring which is enabled by default in OCP 3.11

#### How should this be manually tested?
Validate configuration to open port is correct

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @redhat-cop/casl
