### PR TITLE
Fix #322 - Add lvm prep steps to pre-install

### DIFF
--- a/playbooks/openshift/pre-install.yml
+++ b/playbooks/openshift/pre-install.yml
@@ -24,6 +24,13 @@
         ansible_become: True
       when:
         - rhsm_register
+    # NOTE: This shall be before the container storage, so the next step
+    #       can use all the remaining storage.
+    - import_role:
+        name: ../../galaxy/infra-ansible/roles/config-lvm
+      vars:
+        ansible_become: True
+      when: lvm_entries is defined
     # NOTE: this "openstack" role is generic and can be used across all cloud
     #       providers. We should work with the `openshift-ansible` team to get
     #       this corrected - i.e.: made generic.


### PR DESCRIPTION
In some environments the rootfs might be very restricted (so you
must put /var/lib/etcd on a lv) or you might want to enable quotas
for emptydir (so you must put /var/lib/origin/openshift.local.volumes)
on a volume mounted with the gquota option.

By using ansible-infra's config-lvm role, we are able to set these
volumes through the inventory and having casl configuring them
upfront.

#### Who would you like to review this?
cc: @redhat-cop/casl @ckyriakidou
