### PR TITLE
Only set up docker storage for when it isn't defined

### DIFF
--- a/playbooks/openshift/pre-install.yml
+++ b/playbooks/openshift/pre-install.yml
@@ -4,10 +4,12 @@
 # OpenShift Pre-Requisites
 
 # Ensure the 'docker_storage_block_device' is correctly populated for all nodes
+# if not yet defined
 - hosts: nodes
   tasks:
     - set_fact:
         docker_storage_block_device: "{{ hostvars['localhost'].docker_storage_block_device }}"
+      when: docker_storage_block_device is undefined
 
 #
 # - subscribe hosts


### PR DESCRIPTION
#### What does this PR do?
Ensures that docker_storage_block_device is not overwritten if it's already defined
https://github.com/redhat-cop/casl-ansible/blob/5a7dfb7cc74b16585002726467174b6a2cb7e940/playbooks/openshift/prep-inventory.yml#L47 this is the only place mentioned in the code where it is defined and it's crucial to get this defined in advance for BYO infrastructure or different images for AWS, and Openstack.

#### Who would you like to review this?
cc: @redhat-cop/casl
