### PR TITLE
Adds a new role (openshift-label-by-expression) which allows you to apply a label to all objects (except Pods) which match a given expression

### DIFF
--- a/roles/openshift-label-by-expression/README.md
+++ b/roles/openshift-label-by-expression/README.md
@@ -1,5 +1,9 @@
 # Apply a given label to OpenShift objects based on a name pattern
 
+## Overview
+This role allows you to apply a label to all objects (except Pods) which match a given expression. This is useful for applying
+labels to items which all contain a certain string. This role will OVERWRITE ALL EXISTING LABELS for those objects.
+
 ## Example:
 ```yaml
 ---

--- a/roles/openshift-label-by-expression/README.md
+++ b/roles/openshift-label-by-expression/README.md
@@ -1,0 +1,14 @@
+# Apply a given label to OpenShift objects based on a name pattern
+
+## Example:
+```yaml
+---
+- hosts: localhost
+
+  roles:
+    - role: openshift-label-by-expression
+      vars:
+        target_namespace: labs-ci-cd      ## Apply this to ONLY objects in the specified namespace
+        name_pattern: ".*selenium.*"      ## Regex patterns are supported
+        label: 'app=selenium'             ## The label to be applied
+```

--- a/roles/openshift-label-by-expression/tasks/main.yml
+++ b/roles/openshift-label-by-expression/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: "Find all objects in namespace '{{ target_namespace }}'"
+  command: >
+    oc get all --no-headers --output="name" --namespace="{{ target_namespace }}"
+  when:
+  - target_namespace is defined
+  - target_namespace|trim != ''
+  - name_pattern is defined
+  - name_pattern|trim != ''
+  register: ocp_objects
+- name: "Apply label"
+  command: >
+    oc label --overwrite --namespace={{ target_namespace }} {{ item }} {{ label }}
+  with_items: "{{ ocp_objects.stdout_lines }}"
+  when:
+  - target_namespace is defined
+  - target_namespace|trim != ''   ## target_namespace IS REQUIRED
+  - name_pattern is defined
+  - name_pattern|trim != ''       ## name_pattern IS REQUIRED
+  - item is search(name_pattern)  ## Only apply labels to objects matching this expression
+  - not(item is match('pods/*'))  ## Cannot apply labels to pods, so filter those out


### PR DESCRIPTION
#### What does this PR do?
Adds a new role (openshift-label-by-expression) which allows you to apply a label to all objects (except Pods) which match a given expression.

#### How should this be manually tested?
Apply the following example playbook:
```
---
- hosts: localhost

  roles:
    - role: openshift-label-by-expression
      vars:
        target_namespace: labs-ci-cd      ## Apply this to ONLY objects in the specified namespace
        name_pattern: ".*selenium.*"      ## Regex patterns are supported
        label: 'app=selenium'             ## The label to be applied
```

#### Is there a relevant Issue open for this?
#339 

#### Other Relevant info, PRs, etc.
N/A

#### Who would you like to review this?
cc: @oybed @logandonley @tylerauerbeck 
