### PR TITLE
added persistent disk for docker storage

### DIFF
--- a/inventory/sample.gcp.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/sample.gcp.example.com.d/inventory/group_vars/all.yml
@@ -29,6 +29,8 @@ cloud_infrastructure:
      name_prefix: master
      preemptible: false
      docker_volume_size: 12
+# docker volume type options are persistent or ephemeral (default persistent)     
+     docker_volume_type: persistent
    appnodes:
      count: 3
      flavor: n1-standard-4
@@ -39,6 +41,7 @@ cloud_infrastructure:
      name_prefix: node
      preemptible: false
      docker_volume_size: 50
+     docker_volume_type: persistent
    infranodes:
      count: 3
      flavor: n1-standard-4
@@ -49,9 +52,11 @@ cloud_infrastructure:
      name_prefix: infranode
      preemptible: false
      docker_volume_size: 20
+     docker_volume_type: persistent
 
-# docker_storage_block_device: "/dev/vdb"
-# docker_storage_mount_point: "/var/lib/containers/docker"
+docker_volume_name: docker-storage
+container_runtime_docker_storage_setup_device: /dev/disk/by-id/google-{{ gcloud_docker_volume_name }}
+container_runtime_docker_storage_type: overlay2
 
 # Subscription Management Details
 rhsm_register: True

--- a/roles/manage-gcp-infra/defaults/main.yml
+++ b/roles/manage-gcp-infra/defaults/main.yml
@@ -12,13 +12,16 @@ cloud_infrastructure:
     preemptible: false
   # default docker volume size  
     docker_volume_size: 10
+    docker_volume_type: persistent
   appnodes:
     name_prefix: node
     flavor: n1-standard-2
     preemptible: false
     docker_volume_size: 50
+    docker_volume_type: persistent
   infranodes:
     name_prefix: infranode
     flavor: n1-standard-2
     preemptible: false
     docker_volume_size: 20
+    docker_volume_type: persistent

--- a/roles/manage-gcp-infra/templates/openshift-gcloud.yaml.j2
+++ b/roles/manage-gcp-infra/templates/openshift-gcloud.yaml.j2
@@ -15,6 +15,18 @@ resources:
           diskSizeGb: {{ gcloud_vm_disk_size }}
           sourceImage: https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7
           diskType: pd-ssd
+{% if gcloud_masters_docker_volume_type == 'persistent' %}          
+      - deviceName: {{ gcloud_docker_volume_name }}
+        boot: false           
+        index: 1
+        kind: compute#attachedDisk
+        type: persistent
+        autoDelete: true
+        initializeParams:
+          diskType: pd-ssd
+          diskSizeGb: {{ gcloud_masters_docker_volume_size }}                
+{% endif %}
+{% if gcloud_masters_docker_volume_type == 'ephemeral' %}          
       - autoDelete: true
         boot: false
         index: 1
@@ -22,6 +34,7 @@ resources:
         type: SCRATCH
         initializeParams:
           diskType: local-ssd
+{% endif %}          
       machineType: {{ gcloud_masters_flavor }}
       networkInterfaces:
       - accessConfigs:
@@ -60,6 +73,18 @@ resources:
           diskSizeGb: {{ gcloud_vm_disk_size }}
           sourceImage: https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7
           diskType: pd-ssd
+{% if gcloud_appnodes_docker_volume_type == 'persistent' %}          
+      - deviceName: {{ gcloud_docker_volume_name }}
+        boot: false           
+        index: 1
+        kind: compute#attachedDisk
+        type: persistent
+        autoDelete: true
+        initializeParams:
+          diskType: pd-standard
+          diskSizeGb: {{ gcloud_appnodes_docker_volume_size }}                
+{% endif %}
+{% if gcloud_appnodes_docker_volume_type == 'ephemeral' %}          
       - autoDelete: true
         boot: false
         index: 1
@@ -67,6 +92,7 @@ resources:
         type: SCRATCH
         initializeParams:
           diskType: local-ssd
+{% endif %}
       machineType: {{ gcloud_appnodes_flavor }}
       networkInterfaces:
       - accessConfigs:
@@ -105,6 +131,18 @@ resources:
           diskSizeGb: {{ gcloud_vm_disk_size }}
           sourceImage: https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/family/rhel-7
           diskType: pd-ssd
+{% if gcloud_infranodes_docker_volume_type == 'persistent' %}          
+      - deviceName: {{ gcloud_docker_volume_name }}
+        boot: false           
+        index: 1
+        kind: compute#attachedDisk
+        type: persistent
+        autoDelete: true
+        initializeParams:
+          diskType: pd-standard
+          diskSizeGb: {{ gcloud_infranodes_docker_volume_size }}                
+{% endif %}
+{% if gcloud_infranodes_docker_volume_type == 'ephemeral' %}          
       - autoDelete: true
         boot: false
         index: 1
@@ -112,6 +150,7 @@ resources:
         type: SCRATCH
         initializeParams:
           diskType: local-ssd
+{% endif %}
       machineType: {{ gcloud_infranodes_flavor }}
       networkInterfaces:
       - accessConfigs:

--- a/roles/manage-gcp-infra/vars/main.yaml
+++ b/roles/manage-gcp-infra/vars/main.yaml
@@ -30,6 +30,10 @@ gcloud_masters_docker_volume_size: "{{ cloud_infrastructure.masters.docker_volum
 gcloud_appnodes_docker_volume_size: "{{ cloud_infrastructure.appnodes.docker_volume_size }}"
 gcloud_infranodes_docker_volume_size: "{{ cloud_infrastructure.infranodes.docker_volume_size }}"
 
+gcloud_masters_docker_volume_type: "{{ cloud_infrastructure.masters.docker_volume_type }}"
+gcloud_appnodes_docker_volume_type: "{{ cloud_infrastructure.appnodes.docker_volume_type }}"
+gcloud_infranodes_docker_volume_type: "{{ cloud_infrastructure.infranodes.docker_volume_type }}"
+
 gcloud_region: "{{ cloud_infrastructure.region }}"
 gcloud_project_name: "{{ project_id }}"
 gcloud_managed_zone: "{{ dns_domain }}"
@@ -37,7 +41,7 @@ gcloud_env: "{{ env_id }}"
 gcloud_master_external_fqdn: "{{ openshift_master_cluster_public_hostname }}"
 gcloud_master_internal_fqdn: "{{ openshift_master_cluster_hostname }}"
 gcloud_infranode_wildcard_fqdn: "*.{{ openshift_master_default_subdomain }}"
-gcloud_docker_volume_name: docker-storage
+gcloud_docker_volume_name: "{{ docker_volume_name }}"
 gcloud_vm_disk_size: 50
 gcloud_registry_configmap_name: registry-config
 gcloud_registry_bucket_name: "{{ google_registry_bucket_name }}" 


### PR DESCRIPTION
also re-established using the added disk for docker storage

#### What does this PR do?
I wanted to have the option to use persistent disk for docker storage as opposed to only ephemeral disk.
My hope was that in doing so it would be possible again to shut down the instances. 
Unfortunately this is not enough because we are using instance managers, which restart the instances.
Anyway, this is still worth having.
I also re-added the property to use the added disk for docker storage, based on the new prep steps.

#### Who would you like to review this?
cc: @redhat-cop/casl
