### PR TITLE
Added python-ovirt-engine-sdk4 to casl-origin Dockerfile

### DIFF
--- a/images/casl-ansible/Dockerfile
+++ b/images/casl-ansible/Dockerfile
@@ -4,10 +4,13 @@ USER root
 
 # Update System and install clients
 RUN \
-    yum install -y --setopt=tsflags=nodocs https://repos.fedorapeople.org/repos/openstack/openstack-queens/rdo-release-queens-1.noarch.rpm; \
+    yum install -y --setopt=tsflags=nodocs \
+    https://repos.fedorapeople.org/repos/openstack/openstack-queens/rdo-release-queens-1.noarch.rpm \
+    http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm; \
     yum -y install python2-pip; \
     pip install --upgrade pip; \
     yum -y install \
+      python-ovirt-engine-sdk4 \
       python-ceilometerclient \
       python-cinderclient python-glanceclient \
       python-heatclient python-neutronclient \


### PR DESCRIPTION
What does this PR do?
In order to add RHV as a provider we need the casl-ansible docker image to contain the necessary ovirt SDK to interact with the APIs. This PR updates the Dockerfile to add a repo and rpm that accomplishes that.

How should this be manually tested?
This has been tested to build properly with the following commands
```
cd casl-ansible (git root)
docker build . -t custom/casl-ansible -f images/casl-ansible/Dockerfile
```

Is there a relevant Issue open for this?
resolves #342

Other Relevant info, PRs, etc.
This is a pre-req for future PRs related to adding the RHV provider

Who would you like to review this?
cc: @redhat-cop/casl