### PR TITLE
Fix with_sequence in create_users role.

### DIFF
--- a/roles/create_users/tasks/create_users.yml
+++ b/roles/create_users/tasks/create_users.yml
@@ -19,8 +19,5 @@
     owner: root
     group: root
     mode: 0600
-  with_sequence:
-    start: 0
-    end: "{{ users.num_users }}"
-    format: "{{ users.prefix }}%02d"
+  with_sequence: start=0 end="{{ users.num_users }}" format="{{ users.prefix }}%02d"
 


### PR DESCRIPTION
*with_sequence* does not support dictionary format in recent versions of Ansible. I know, it looks horrible.

Otherwise the task fails with this error message:
```
"msg": "unrecognized arguments to with_sequence: [u'_raw_params']"
}
```

Related issues:
https://github.com/ansible/ansible/issues/22988
https://github.com/openshift/openshift-ansible/pull/10056/files

It is documented this way:
https://docs.ansible.com/ansible/2.5/plugins/lookup/sequence.html

#### What does this PR do?
Brief explanation of the code or documentation change you have made

#### How should this be manually tested?
Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

Use `resolves #<pr-number>` to auto-close at merge time

#### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc.)

#### Who would you like to review this?
cc: @redhat-cop/casl
