### PR TITLE
added openshift_hosted_registry_storage_annotations to cinder storage…

### DIFF
--- a/inventory/sample.osp.example.com.d/inventory/group_vars/all.yml
+++ b/inventory/sample.osp.example.com.d/inventory/group_vars/all.yml
@@ -103,6 +103,8 @@ openshift_hosted_registry_storage_kind: openstack
 #openshift_hosted_registry_storage_openstack_filesystem: ext4
 #openshift_hosted_registry_storage_openstack_volumeID: 3a650b4f-c8c5-4e0a-8ca5-eaee11f16c57
 #openshift_hosted_registry_storage_volume_size: 20Gi
+#openshift_hosted_registry_storage_annotations:
+#- 'volume.beta.kubernetes.io/storage-class: standard'
 
 
 # Subscription Management Details

--- a/playbooks/openshift/openstack/cinder-registry.yml
+++ b/playbooks/openshift/openstack/cinder-registry.yml
@@ -20,7 +20,7 @@
       openshift_hosted_registry_storage_access_modes: "{{ openshift_hosted_registry_storage_access_modes | default(\"['ReadWriteOnce']\") }}"
       openshift_hosted_registry_storage_openstack_filesystem: "{{ openshift_hosted_registry_storage_openstack_filesystem | default('ext4')}}"
       openshift_hosted_registry_storage_annotations:
-      - 'volume.beta.kubernetes.io/storage-class: standard'
+      - "volume.beta.kubernetes.io/storage-class: {{ openshift_hosted_registry_storage_class | default('standard') }}"
     with_items:
     -  "{{ hostvars['localhost'].os_volumes.results }}"
     when:

--- a/playbooks/openshift/openstack/cinder-registry.yml
+++ b/playbooks/openshift/openstack/cinder-registry.yml
@@ -19,6 +19,8 @@
       openshift_hosted_registry_storage_volume_size: "{{ disk.volume.size }}Gi"
       openshift_hosted_registry_storage_access_modes: "{{ openshift_hosted_registry_storage_access_modes | default(\"['ReadWriteOnce']\") }}"
       openshift_hosted_registry_storage_openstack_filesystem: "{{ openshift_hosted_registry_storage_openstack_filesystem | default('ext4')}}"
+      openshift_hosted_registry_storage_annotations:
+      - 'volume.beta.kubernetes.io/storage-class: standard'
     with_items:
     -  "{{ hostvars['localhost'].os_volumes.results }}"
     when:


### PR DESCRIPTION
#### What does this PR do?
Adds openshift_hosted_registry_storage_annotations variable to cinder-registry.yml. 

#### How should this be manually tested?
This is to fix the static registry bug. It works with an open [pr](https://github.com/openshift/openshift-ansible/pull/10948) in openshift-ansible. Once this is merged in the bug should be fixed, but until then you must ensure that openshift-ansible in galaxy is on the pr branch. It can be tested against an openstack deployment with `openshift_hosted_registry_storage_kind: openstack`.

#### Is there a relevant Issue open for this?
#301 

#### Who would you like to review this?
cc: @redhat-cop/casl
