### PR TITLE
Updates to allow for use of latest 'infra-ansible' and other v3.11 fixes

### DIFF
--- a/casl-requirements.yml
+++ b/casl-requirements.yml
@@ -4,11 +4,11 @@
 
 # From 'infra-ansible'
 - src: https://github.com/redhat-cop/infra-ansible
-  version: v1.0.4
+  version: v1.0.8
 
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.4
+  version: v2.0.7
 
 # From 'openshift-ansible'
 - src: https://github.com/openshift/openshift-ansible

--- a/playbooks/openshift/openstack/dns-records.yml
+++ b/playbooks/openshift/openstack/dns-records.yml
@@ -3,7 +3,7 @@
 - name: "Start with a clean list of records"
   set_fact:
     a_records: []
-    named_records: []
+    nsupdate_servers: []
 
 - name: "Set the DNS zone to use"
   set_fact:
@@ -11,11 +11,11 @@
 
 - name: "Generate list of A records"
   set_fact:
-    a_records: "{{ a_records | default([]) +
+    a_records: "{{ a_records +
                    [{
                       'type': 'A',
-                      'hostname': (hostvars[item]['ansible_fqdn'] | replace('.' + nsupdate_zone, '')),
-                      'ip': hostvars[item][nsupdate.view + '_v4']
+                      'record': (hostvars[item]['ansible_fqdn'] | replace('.' + nsupdate_zone, '')),
+                      'value': hostvars[item][nsupdate.view + '_v4']
                    }]
                  }}"
   with_items:
@@ -23,11 +23,11 @@
 
 - name: "Add wildcard records to the A records for infrahosts"
   set_fact:
-    a_records: "{{ a_records | default([]) +
+    a_records: "{{ a_records +
                    [{
                       'type': 'A',
-                      'hostname': '*.' + (openshift_master_default_subdomain | replace('.' + nsupdate_zone, '')),
-                      'ip': hostvars[item][nsupdate.view + '_v4']
+                      'record': '*.' + (openshift_master_default_subdomain | replace('.' + nsupdate_zone, '')),
+                      'value': hostvars[item][nsupdate.view + '_v4']
                    }]
                 }}"
   when:
@@ -54,32 +54,39 @@
 
 - name: "Add public master cluster hostname records to the A records"
   set_fact:
-    a_records: "{{ a_records | default([]) +
+    a_records: "{{ a_records +
                    [{
                       'type': 'A',
-                      'hostname': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone, ''))[:-1],
-                      'ip': master_ip
+                      'record': (hostvars[groups.masters[0]].openshift_master_cluster_public_hostname | replace(nsupdate_zone, ''))[:-1],
+                      'value': master_ip
                    }]
                 }}"
   when:
     - hostvars[groups.masters[0]].openshift_master_cluster_public_hostname is defined
 
-- name: "Generate the Add section for DNS for all nsupdate servers"
+- name: "Generate the nsupdate server list"
   set_fact:
-    named_records: "{{ named_records | default([]) +
-                       [{
-                          'view': nsupdate.view,
-                          'zone': nsupdate.zone,
-                          'server': item.server,
-                          'key_name': item.key_name,
-                          'key_secret': item.key_secret,
-                          'key_algorithm': (item.key_algorithm | lower),
-                          'entries': a_records
-                       }]
-                    }}"
+    nsupdate_servers: "{{ nsupdate_servers +
+                         [{
+                           'server': item.server,
+                           'key_name': item.key_name,
+                           'key_secret': item.key_secret,
+                           'key_algorithm': (item.key_algorithm|lower)
+                         }]
+                       }}"
   with_items:
     - "{{ nsupdate.server_list }}"
 
-- name: "Add to 'dns_records_add' list"
+- name: "Generate the Add section for DNS for all nsupdate servers"
   set_fact:
-    dns_records_add: "{{ dns_records_add | default([]) + named_records }}"
+    dns_view:
+      - name: "{{ nsupdate.view }}"
+        zones:
+          - dns_domain: "{{ nsupdate.zone }}"
+            nsupdate: "{{ nsupdate_servers }}"
+            entries: "{{ a_records }}"
+
+- name: "Add to 'dns_data' dictionary"
+  set_fact:
+    dns_data:
+      views: "{{ dns_data.views + dns_view }}"

--- a/playbooks/openshift/openstack/dns.yml
+++ b/playbooks/openshift/openstack/dns.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: "Prepare facts for DNS records"
+  set_fact:
+    dns_data:
+      views: []
+
 - name: "Set the private(internal) and public(external) DNS to use (if provided)"
   include_tasks: dns-records.yml
   with_items:

--- a/playbooks/openshift/openstack/post-provision.yml
+++ b/playbooks/openshift/openstack/post-provision.yml
@@ -10,7 +10,6 @@
     set_fact:
       private_v4: "{{ openstack.private_v4 }}"
       public_v4: "{{ openstack.public_v4 }}"
-      openshift_hostname: "{{ inventory_hostname }}"
       openshift_public_hostname: "{{ inventory_hostname }}"
   roles:
   - role: ../../../galaxy/infra-ansible/roles/config-hostname
@@ -22,7 +21,7 @@
   - import_tasks: ../prep-inventory.yml
   - import_tasks: dns.yml
   roles:
-  - role: ../../../galaxy/infra-ansible/roles/dns
+  - role: ../../../galaxy/infra-ansible/roles/dns/manage-dns-records
 
 # provision cinder volume
 - import_playbook: cinder-registry.yml

--- a/playbooks/openshift/pre-install.yml
+++ b/playbooks/openshift/pre-install.yml
@@ -26,6 +26,8 @@
         ansible_become: True
       when:
         - rhsm_register
+    - import_role:
+        name: ../../galaxy/infra-ansible/roles/manage-server-ca-cert
     # NOTE: This shall be before the container storage, so the next step
     #       can use all the remaining storage.
     - import_role:


### PR DESCRIPTION
#### What does this PR do?
This PR updates the DNS handling to be able to utilize the latest `infra-ansible` repo + it adds the call to `manage-server-ca-cert` to allow customer CA certificates to be installed in the event that this is needed. 

#### How should this be manually tested?
Perform a full `casl-ansible` installation on OpenStack

#### Is there a relevant Issue open for this?
N/A

#### Other Relevant info, PRs, etc.
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl @tylerauerbeck @bvkin 