### PR TITLE
Updating openshift-applier version to latest

### DIFF
--- a/casl-requirements.yml
+++ b/casl-requirements.yml
@@ -8,7 +8,7 @@
 
 # From 'openshift-applier'
 - src: https://github.com/redhat-cop/openshift-applier
-  version: v2.0.7
+  version: v2.0.8
 
 # From 'openshift-ansible'
 - src: https://github.com/openshift/openshift-ansible


### PR DESCRIPTION
#### What does this PR do?
Updating openshift-applier version to the latest - i.e.: `v2.0.8`

#### How should this be manually tested?
Run the `ansible-galaxy` command to see that the correct openshift-applier gets pulled in

#### Is there a relevant Issue open for this?
N/A

#### Other Relevant info, PRs, etc.
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
