### PR TITLE
Fixed openshift_configure_container_storage bug

### DIFF
--- a/playbooks/openshift/prep-inventory.yml
+++ b/playbooks/openshift/prep-inventory.yml
@@ -57,7 +57,7 @@
   set_fact:
     openshift_openstack_ephemeral_volumes: true
   when:
-    - openshift_configure_container_storage == false
+    - openshift_configure_container_storage | default(true) == false
     - hosting_infrastructure == "openstack"
 
 - name: Set the packages to install on the target systems


### PR DESCRIPTION
#### What does this PR do?
Fixes bug where prep-inventory.yml playbook errors out if openshift_configure_container_storage is not set.

#### How should this be manually tested?
Provision an casl cluster both with and without this variable set. 

#### Is there a relevant Issue open for this?
resolves #360 

#### Who would you like to review this?
cc: @redhat-cop/casl
