### PR TITLE
Fixed delay and retries vals not cast to int in Query Replica Status …

### DIFF
--- a/roles/openshift-replicas-ready/tasks/main.yml
+++ b/roles/openshift-replicas-ready/tasks/main.yml
@@ -16,7 +16,7 @@
   command: >
     oc get {{ type }}/{{ resource }} {{ target_namespace }} -o json
   register: query_result
-  delay: "{{ delay }}"
-  retries: "{{ retries }}"
+  delay: "{{ delay | int }}"
+  retries: "{{ retries | int }}"
   until: (query_result.stdout | from_json)['spec']['replicas'] | default("0") | int == (query_result.stdout | from_json)['status']['readyReplicas'] | default("0") | int
   failed_when: (query_result.stdout | from_json)['spec']['replicas'] is not defined


### PR DESCRIPTION
…task.

#### What does this PR do?
The Query Replica Status task was failing because the delay and retries vals weren't being cast as ints.

#### How should this be manually tested?
Run a playbook using this task without defining a `delay` or `retries` val set.

#### Is there a relevant Issue open for this?
Not that I know of.

#### Other Relevant info, PRs, etc.

#### Who would you like to review this?
cc: @oybed 
