### PR TITLE
removed dns configuration vars from OSEv3 in aws example inventory

### DIFF
--- a/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
+++ b/inventory/sample.aws.example.com.d/inventory/group_vars/OSEv3.yml
@@ -34,11 +34,7 @@ osm_cockpit_plugins:
 # Enable the Multi-Tenant plugin
 os_sdn_network_plugin_name: 'redhat/openshift-ovs-multitenant'
 
-# OpenShift FQDNs, DNS, App domain specific configurations
 openshift_master_cluster_method: native
-openshift_master_default_subdomain: "apps.{{ env_id }}.{{ dns_domain }}"
-openshift_master_cluster_hostname: "console.internal.{{ env_id }}.{{ dns_domain }}"
-openshift_master_cluster_public_hostname: "console.{{ env_id }}.{{ dns_domain }}"
 
 # Registry URL & Credentials
 # For more info: https://access.redhat.com/terms-based-registry/


### PR DESCRIPTION
#### What does this PR do?
Removed dns related variables from OSEv3.yml in the aws example inventory. These need to be set only in all.yml as cloudformation is managed by localhost which is not part of OSEv3.

#### Who would you like to review this?
cc: @redhat-cop/casl
