### PR TITLE
Fix label role

### DIFF
--- a/roles/openshift-labels/tasks/main.yml
+++ b/roles/openshift-labels/tasks/main.yml
@@ -6,7 +6,9 @@
 
 - name: "Prepend '-n' to the namespace, unless already set"
   set_fact:
-    namespace_param: "{{ ((processed_namespace|trim).find('-n') == 0) | ternary(processed_namespace, '-n ' + processed_namespace) }}"
+    namespace_param: "{% if ((processed_namespace|trim).find('-n') != 0) %}-n {% endif %}{{ processed_namespace }}"
+  when:
+    - processed_namespace|length > 0
 
 - name: "Apply label {{ label }} to object {{ target_object }}"
   command: >

--- a/roles/openshift-labels/tasks/main.yml
+++ b/roles/openshift-labels/tasks/main.yml
@@ -4,9 +4,9 @@
   set_fact:
     processed_namespace: "{{ target_namespace | default('') }}"
 
-- name: Empty namespace param when not needed
+- name: "Prepend '-n' to the namespace, unless already set"
   set_fact:
-    namespace_param: "{{ (processed_namespace|length > 0) | ternary('-n ' + processed_namespace, '') }}"
+    namespace_param: "{{ ((processed_namespace|trim).find('-n') == 0) | ternary(processed_namespace, '-n ' + processed_namespace) }}"
 
 - name: "Apply label {{ label }} to object {{ target_object }}"
   command: >


### PR DESCRIPTION
#### What does this PR do?
The label role is blindly prepending `-n` to the namespace. This is wrong in those cases where the namespace argument already starts with `-n`. This PR fixes this in a smarter way as it conditionally add `-n` only if it's not already there at the start of the variable. 

#### How should this be manually tested?
Run the `tests/inventories/pre-post-steps` in the `openshift-applier` repo.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
