### PR TITLE
Fixing namespace handling to be a bit more robust for openshift-labels role

### DIFF
--- a/roles/openshift-labels/defaults/main.yml
+++ b/roles/openshift-labels/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+target_namespace: ''
+namespace_param: ''

--- a/roles/openshift-labels/tasks/main.yml
+++ b/roles/openshift-labels/tasks/main.yml
@@ -1,14 +1,10 @@
 ---
 
-- name: "Set defaults"
-  set_fact:
-    processed_namespace: "{{ target_namespace | default('') }}"
-
 - name: "Prepend '-n' to the namespace, unless already set"
   set_fact:
-    namespace_param: "{% if ((processed_namespace|trim).find('-n') != 0) %}-n {% endif %}{{ processed_namespace }}"
+    namespace_param: "{% if ((target_namespace|trim).find('-n') != 0) %}-n {% endif %}{{ target_namespace }}"
   when:
-    - processed_namespace|length > 0
+    - target_namespace|length > 0
 
 - name: "Apply label {{ label }} to object {{ target_object }}"
   command: >


### PR DESCRIPTION
#### What does this PR do?
Changes the handling of the namespace parameter to align with desire functionality + making it a bit more robust. Also aligns more with the coming functionality in PR #383 

#### How should this be manually tested?
Utilize the role to label an OpenShift (or k8s) object

#### Is there a relevant Issue open for this?
resolves #379 

#### Other Relevant info, PRs, etc.
#383 

#### Who would you like to review this?
cc: @redhat-cop/casl @tylerauerbeck 
