### PR TITLE
Add namespace scope to openshift-route-status

### DIFF
--- a/roles/openshift-route-status/tasks/main.yml
+++ b/roles/openshift-route-status/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
 
+- name: "Prepend '-n' to the namespace, unless already set"
+  set_fact:
+    namespace_param: "{% if ((target_namespace|trim).find('-n') != 0) %}-n {% endif %}{{ target_namespace }}"
+  when:
+    - target_namespace|length > 0
+
 - name: "Lookup route url for {{ route }}"
-  shell: "oc get route {{ route }} -o jsonpath='{ .spec.host }'"
+  shell: "oc get route {{ route }} -o jsonpath='{ .spec.host }' {{ namespace_param }}"
   register: url
   when:
   - route is defined


### PR DESCRIPTION
#### What does this PR do?
This adds the ability to supply a namespace to check a route in a specific namespace

#### How should this be manually tested?
Use the following vars with the `openshift-route-status` role and specify a route that isn't in your current project.

```
route: my-route
protocol: https
status: 200
namespace: my-project
retries: 5
```

#### Is there a relevant Issue open for this?
N/A

#### Other Relevant info, PRs, etc.
N/A

#### Who would you like to review this?
cc: @redhat-cop/casl
